### PR TITLE
feat(client): replace long256 string with big.Int

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -41,6 +41,7 @@ import (
 	"net"
 	"strconv"
 	"time"
+	"unicode/utf8"
 )
 
 // ErrInvalidMsg indicates a failed attempt to construct an ILP
@@ -333,7 +334,7 @@ func (s *LineSender) Int64Column(name string, val int64) *LineSender {
 // Column name cannot contain any of the following characters:
 // '\n', '\r', '?', '.', ',', ”', '"', '\\', '/', ':', ')', '(', '+',
 // '-', '*' '%%', '~', or a non-printable char.
-func (s *LineSender) Long256Column(name, val string) *LineSender {
+func (s *LineSender) Long256Column(name string, val *big.Int) *LineSender {
 	if !s.prepareForField(name) {
 		return s
 	}
@@ -342,7 +343,12 @@ func (s *LineSender) Long256Column(name, val string) *LineSender {
 		return s
 	}
 	s.buf.WriteByte('=')
-	s.lastErr = s.writeStrValue(val, false)
+	hexVal := "0x"
+	if utf8.RuneCountInString(val.Text(16))%2==1 {
+		hexVal += "0"
+	}
+	hexVal += val.Text(16) + "i"
+	s.lastErr = s.writeStrValue(hexVal, false)
 	if s.lastErr != nil {
 		return s
 	}

--- a/sender_integration_test.go
+++ b/sender_integration_test.go
@@ -29,6 +29,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
+	"math/big"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -236,7 +238,7 @@ func TestE2EValidWrites(t *testing.T) {
 					Symbol("sym_col", "test_ilp1").
 					Float64Column("double_col", 12.2).
 					Int64Column("long_col", 12).
-					Long256Column("long256_col", "0x123a4i").
+					Long256Column("long256_col", big.NewInt(0).SetInt64(0x123a4)).
 					StringColumn("str_col", "foobar").
 					BoolColumn("bool_col", true).
 					TimestampColumn("timestamp_col", 42).
@@ -250,7 +252,7 @@ func TestE2EValidWrites(t *testing.T) {
 					Symbol("sym_col", "test_ilp2").
 					Float64Column("double_col", 11.2).
 					Int64Column("long_col", 11).
-					Long256Column("long256_col", "0x123a3i").
+					Long256Column("long256_col",  big.NewInt(0).SetInt64(7423093023234231)).
 					StringColumn("str_col", "barbaz").
 					BoolColumn("bool_col", false).
 					TimestampColumn("timestamp_col", 43).
@@ -269,7 +271,7 @@ func TestE2EValidWrites(t *testing.T) {
 				},
 				Dataset: [][]interface{}{
 					{"test_ilp1", float64(12.2), float64(12), "0x0123a4", "foobar", true, "1970-01-01T00:00:00.000042Z", "1970-01-01T00:00:00.000001Z"},
-					{"test_ilp2", float64(11.2), float64(11), "0x0123a3", "barbaz", false, "1970-01-01T00:00:00.000043Z", "1970-01-01T00:00:00.000002Z"},
+					{"test_ilp2", float64(11.2), float64(11),"0x1a5f4386c8d8b7" , "barbaz", false, "1970-01-01T00:00:00.000043Z", "1970-01-01T00:00:00.000002Z"},
 				},
 				Count: 2,
 			},
@@ -342,7 +344,7 @@ func TestE2EValidWrites(t *testing.T) {
 			func(s *qdb.LineSender) error {
 				return s.
 					Table(testTable).
-					Long256Column("foobar", "0x123a4i").
+					Long256Column("foobar",  big.NewInt(0).SetInt64(math.MaxInt64)).
 					At(ctx, 42000)
 			},
 			tableData{
@@ -351,7 +353,7 @@ func TestE2EValidWrites(t *testing.T) {
 					{"timestamp", "TIMESTAMP"},
 				},
 				Dataset: [][]interface{}{
-					{"0x0123a4", "1970-01-01T00:00:00.000042Z"},
+					{"0x7fffffffffffffff", "1970-01-01T00:00:00.000042Z"},
 				},
 				Count: 1,
 			},

--- a/sender_integration_test.go
+++ b/sender_integration_test.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -233,12 +232,13 @@ func TestE2EValidWrites(t *testing.T) {
 			"all column types",
 			testTable,
 			func(s *qdb.LineSender) error {
+				val, _ := big.NewInt(0).SetString("123a4", 16)
 				err := s.
 					Table(testTable).
 					Symbol("sym_col", "test_ilp1").
 					Float64Column("double_col", 12.2).
 					Int64Column("long_col", 12).
-					Long256Column("long256_col", big.NewInt(0x123a4)).
+					Long256Column("long256_col", val).
 					StringColumn("str_col", "foobar").
 					BoolColumn("bool_col", true).
 					TimestampColumn("timestamp_col", 42).
@@ -247,12 +247,13 @@ func TestE2EValidWrites(t *testing.T) {
 					return err
 				}
 
+				val, _ = big.NewInt(0).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 				return s.
 					Table(testTable).
 					Symbol("sym_col", "test_ilp2").
 					Float64Column("double_col", 11.2).
 					Int64Column("long_col", 11).
-					Long256Column("long256_col",  big.NewInt(7423093023234231)).
+					Long256Column("long256_col", val).
 					StringColumn("str_col", "barbaz").
 					BoolColumn("bool_col", false).
 					TimestampColumn("timestamp_col", 43).
@@ -271,7 +272,7 @@ func TestE2EValidWrites(t *testing.T) {
 				},
 				Dataset: [][]interface{}{
 					{"test_ilp1", float64(12.2), float64(12), "0x0123a4", "foobar", true, "1970-01-01T00:00:00.000042Z", "1970-01-01T00:00:00.000001Z"},
-					{"test_ilp2", float64(11.2), float64(11),"0x1a5f4386c8d8b7" , "barbaz", false, "1970-01-01T00:00:00.000043Z", "1970-01-01T00:00:00.000002Z"},
+					{"test_ilp2", float64(11.2), float64(11), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "barbaz", false, "1970-01-01T00:00:00.000043Z", "1970-01-01T00:00:00.000002Z"},
 				},
 				Count: 2,
 			},
@@ -342,9 +343,10 @@ func TestE2EValidWrites(t *testing.T) {
 			"single column long256",
 			testTable,
 			func(s *qdb.LineSender) error {
+				val, _ := big.NewInt(0).SetString("7fffffffffffffff", 16)
 				return s.
 					Table(testTable).
-					Long256Column("foobar",  big.NewInt(0).SetInt64(math.MaxInt64)).
+					Long256Column("foobar", val).
 					At(ctx, 42000)
 			},
 			tableData{

--- a/sender_integration_test.go
+++ b/sender_integration_test.go
@@ -238,7 +238,7 @@ func TestE2EValidWrites(t *testing.T) {
 					Symbol("sym_col", "test_ilp1").
 					Float64Column("double_col", 12.2).
 					Int64Column("long_col", 12).
-					Long256Column("long256_col", big.NewInt(0).SetInt64(0x123a4)).
+					Long256Column("long256_col", big.NewInt(0x123a4)).
 					StringColumn("str_col", "foobar").
 					BoolColumn("bool_col", true).
 					TimestampColumn("timestamp_col", 42).
@@ -252,7 +252,7 @@ func TestE2EValidWrites(t *testing.T) {
 					Symbol("sym_col", "test_ilp2").
 					Float64Column("double_col", 11.2).
 					Int64Column("long_col", 11).
-					Long256Column("long256_col",  big.NewInt(0).SetInt64(7423093023234231)).
+					Long256Column("long256_col",  big.NewInt(7423093023234231)).
 					StringColumn("str_col", "barbaz").
 					BoolColumn("bool_col", false).
 					TimestampColumn("timestamp_col", 43).

--- a/sender_test.go
+++ b/sender_test.go
@@ -187,19 +187,17 @@ func TestInt64Serialization(t *testing.T) {
 
 func TestLong256Column(t *testing.T) {
 	ctx := context.Background()
-	
-	val, _ := big.NewInt(0).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+
 	testCases := []struct {
 		name     string
-		val     *big.Int
+		val      string
 		expected string
 	}{
-		{"zero", big.NewInt(0), "0x0"},
-		{"one", big.NewInt(1), "0x1"},
-		{"32-bit max", big.NewInt(math.MaxInt32), "0x7fffffff"},
-		{"64-bitrandom",big.NewInt(7423093023234231), "0x1a5f4386c8d8b7"},
-		{"256-bit max",val , "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
-		
+		{"zero", "0", "0x0"},
+		{"one", "1", "0x1"},
+		{"32-bit max", strconv.FormatInt(math.MaxInt32, 16), "0x7fffffff"},
+		{"64-bit random", strconv.FormatInt(7423093023234231, 16), "0x1a5f4386c8d8b7"},
+		{"256-bit max", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
 	}
 
 	for _, tc := range testCases {
@@ -210,7 +208,8 @@ func TestLong256Column(t *testing.T) {
 			sender, err := qdb.NewLineSender(ctx, qdb.WithAddress(srv.addr))
 			assert.NoError(t, err)
 
-			err = sender.Table(testTable).Long256Column("a_col", tc.val).AtNow(ctx)
+			newVal, _ := big.NewInt(0).SetString(tc.val, 16)
+			err = sender.Table(testTable).Long256Column("a_col", newVal).AtNow(ctx)
 			assert.NoError(t, err)
 
 			err = sender.Flush(ctx)
@@ -424,6 +423,41 @@ func TestErrorOnNegativeTimestamp(t *testing.T) {
 	err = sender.Table(testTable).TimestampColumn("timestamp_col", -42).AtNow(ctx)
 
 	assert.ErrorContains(t, err, "timestamp cannot be negative: -42")
+	assert.Empty(t, sender.Messages())
+}
+
+func TestErrorOnNegativeLong256(t *testing.T) {
+	ctx := context.Background()
+
+	srv, err := newTestServer(readAndDiscard)
+	assert.NoError(t, err)
+	defer srv.close()
+
+	sender, err := qdb.NewLineSender(ctx, qdb.WithAddress(srv.addr))
+	assert.NoError(t, err)
+	defer sender.Close()
+
+	err = sender.Table(testTable).Long256Column("long256_col", big.NewInt(-42)).AtNow(ctx)
+
+	assert.ErrorContains(t, err, "long256 cannot be negative: -42")
+	assert.Empty(t, sender.Messages())
+}
+
+func TestErrorOnLargerLong256(t *testing.T) {
+	ctx := context.Background()
+
+	srv, err := newTestServer(readAndDiscard)
+	assert.NoError(t, err)
+	defer srv.close()
+
+	sender, err := qdb.NewLineSender(ctx, qdb.WithAddress(srv.addr))
+	assert.NoError(t, err)
+	defer sender.Close()
+
+	bigVal, _ := big.NewInt(0).SetString("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
+	err = sender.Table(testTable).Long256Column("long256_col", bigVal).AtNow(ctx)
+
+	assert.ErrorContains(t, err, "long256 cannot be larger than 256-bit: 260")
 	assert.Empty(t, sender.Messages())
 }
 

--- a/sender_test.go
+++ b/sender_test.go
@@ -187,18 +187,18 @@ func TestInt64Serialization(t *testing.T) {
 
 func TestLong256Column(t *testing.T) {
 	ctx := context.Background()
-	
+	val, _ := big.NewInt(0).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 	testCases := []struct {
 		name     string
 		val     *big.Int
 		expected string
 	}{
-		{"0", big.NewInt(0).SetInt64(0), "0x00"},
-		{"1", big.NewInt(0).SetInt64(1), "0x01"},
-		{"random hex value ", big.NewInt(0).SetInt64(0x0123a4), "0x0123a4"},
-		{"random int64 value ", big.NewInt(0).SetInt64(7423093023234231), "0x1a5f4386c8d8b7"},
-		{"32bit max", big.NewInt(0).SetInt64(math.MaxInt64), "0x7fffffffffffffff"},
-		{"64bit max", big.NewInt(0).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+		{"zero", big.NewInt(0), "0x0"},
+		{"one", big.NewInt(1), "0x1"},
+		{"random 64",big.NewInt(7423093023234231), "0x1a5f4386c8d8b7"},
+		{"32bit max", big.NewInt(math.MaxInt32), "0x7fffffff"},
+		{"256-bit max value",val , "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+		
 	}
 
 	for _, tc := range testCases {

--- a/sender_test.go
+++ b/sender_test.go
@@ -187,6 +187,7 @@ func TestInt64Serialization(t *testing.T) {
 
 func TestLong256Column(t *testing.T) {
 	ctx := context.Background()
+	
 	val, _ := big.NewInt(0).SetString("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16)
 	testCases := []struct {
 		name     string
@@ -195,9 +196,9 @@ func TestLong256Column(t *testing.T) {
 	}{
 		{"zero", big.NewInt(0), "0x0"},
 		{"one", big.NewInt(1), "0x1"},
-		{"random 64",big.NewInt(7423093023234231), "0x1a5f4386c8d8b7"},
-		{"32bit max", big.NewInt(math.MaxInt32), "0x7fffffff"},
-		{"256-bit max value",val , "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+		{"32-bit max", big.NewInt(math.MaxInt32), "0x7fffffff"},
+		{"64-bitrandom",big.NewInt(7423093023234231), "0x1a5f4386c8d8b7"},
+		{"256-bit max",val , "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
 		
 	}
 

--- a/sender_test.go
+++ b/sender_test.go
@@ -32,6 +32,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	"math/big"
 	"net"
 	"reflect"
 	"strconv"
@@ -186,17 +187,18 @@ func TestInt64Serialization(t *testing.T) {
 
 func TestLong256Column(t *testing.T) {
 	ctx := context.Background()
-
+	
 	testCases := []struct {
 		name     string
-		val      string
+		val     *big.Int
 		expected string
 	}{
-		{"random bits ", "0x0123a4i", "0x0123a4"},
-		{"8bit max", "0xffffffffi", "0xffffffff"},
-		{"16bit max", "0xffffffffffffffffi", "0xffffffffffffffff"},
-		{"32bit max", "0xffffffffffffffffffffffffffffffffi", "0xffffffffffffffffffffffffffffffff"},
-		{"64bit long", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffi", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
+		{"0", big.NewInt(0).SetInt64(0), "0x00"},
+		{"1", big.NewInt(0).SetInt64(1), "0x01"},
+		{"random hex value ", big.NewInt(0).SetInt64(0x0123a4), "0x0123a4"},
+		{"random int64 value ", big.NewInt(0).SetInt64(7423093023234231), "0x1a5f4386c8d8b7"},
+		{"32bit max", big.NewInt(0).SetInt64(math.MaxInt64), "0x7fffffffffffffff"},
+		{"64bit max", big.NewInt(0).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}), "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Refs #3 

I am a little confused about what should be updated in `Long256Column()` documentation. Since it accepts many different values. 
Also, I suggest we add a few examples realted to `big.Int` since there are various ways to set it.