### PR TITLE
Adds WriteRaw function to sender

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -810,6 +810,17 @@ func (s *LineSender) Messages() string {
 	return s.buf.String()
 }
 
+// WriteRaw directly writes bytes to the internal buffer
+// This is useful if you want to write pre-constructed
+// ILP messages to the buffer.
+//
+// WARNING: There is no error checking here! Only use
+// this method if you've pre-validated your data to avoid
+// unexpected errors.
+func (s *LineSender) WriteRaw(p []byte) (int, error) {
+	return s.buf.Write(p)
+}
+
 // buffer is a wrapper on top of bytes.buffer. It extends the
 // original struct with methods for writing int64 and float64
 // numbers without unnecessary allocations.


### PR DESCRIPTION
I'm wrapping my `LineSender` in a `Writer` struct that contains the a pointer to the sender, the context, and ilpOpts used to reconstruct it.  This way, in case of an error in `.At()` or `.Flush()`, I can build a new LineSender, copy the buffer from the old sender to the new one, and swap the pointer value to the new Sender.

```go
func (w *Writer) handleIlpError(s *qdb.LineSender) error {
	newSender, err := qdb.NewLineSender(w.ctx, w.ilpOpts...)
	if err != nil {
		return err
	}
	newSender.WriteRaw([]byte(s.Messages()))

	*s = *newSender
}
```

But to do this would require direct access to the underlying buffer.  I don't think it's great to expose this level of internal struct mechanisms, but my idea would work if I could just write directly to the buffer (using an escape-hatch of sorts).

Enter the `LineSender.WriteRaw()` function, which allows a user to write directly to a LineSender's buffer.

The obvious downside is that there's no error-checking.  But maybe if we clearly document its usage (like the [sync.Mutex's TryLock func](https://pkg.go.dev/sync#Mutex.TryLock), it's good enough to keep around?

This is a bit of a workaround, and not a full solution for issues like #10 and #9, but maybe it could enable future development of a connection pool/manager class?

