### PR TITLE
Pins staticcheck to fix tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install staticcheck
-        run: go get honnef.co/go/tools/cmd/staticcheck
+        run: go get honnef.co/go/tools/cmd/staticcheck@2023.1.1
 
       - name: Run linters
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install staticcheck
-        run: go get honnef.co/go/tools/cmd/staticcheck@2023.1.1
+        run: go get honnef.co/go/tools/cmd/staticcheck@2022.1.3
 
       - name: Run linters
         run: |


### PR DESCRIPTION
https://github.com/questdb/go-questdb-client/pull/13/checks

It looks like later versions of staticcheck dropped support for go 1.17. Instead of bumping this package's go verion (and deps), I'll try to find the latest version of staticcheck that works