### PR TITLE
chore(client): add pending message validation to Flush call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.20.x]
     name: Build with Go ${{ matrix.go-version }}
     steps:
       - name: Checkout repository
@@ -21,13 +21,15 @@ jobs:
           stable: false
           go-version: ${{ matrix.go-version }}
 
-      - name: Install staticcheck
-        run: go get honnef.co/go/tools/cmd/staticcheck@2022.1.3
+      - name: Run vet
+        run: go vet ./...
 
-      - name: Run linters
-        run: |
-          go vet ./...
-          staticcheck ./...
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1.3.0
+        with:
+          version: "2023.1.2"
+          install-go: false
+          cache-key: ${{ matrix.go-version }}
 
       - name: Run tests
         run: go test -v ./...

--- a/sender.go
+++ b/sender.go
@@ -754,9 +754,7 @@ func (s *LineSender) At(ctx context.Context, ts int64) error {
 	s.buf.WriteByte('\n')
 
 	s.lastMsgPos = s.buf.Len()
-	s.hasTable = false
-	s.hasTags = false
-	s.hasFields = false
+	s.resetMsgFlags()
 
 	if s.buf.Len() > s.bufCap {
 		return s.Flush(ctx)
@@ -812,6 +810,10 @@ func (s *LineSender) Flush(ctx context.Context) error {
 
 func (s *LineSender) discardPendingMsg() {
 	s.buf.Truncate(s.lastMsgPos)
+	s.resetMsgFlags()
+}
+
+func (s *LineSender) resetMsgFlags() {
 	s.hasTable = false
 	s.hasTags = false
 	s.hasFields = false


### PR DESCRIPTION
Also includes the following:
* Pending invalid message is now discarded on `At`/`AtNow`/`Flush` calls. This way the sender is kept usable even after an incorrect chain of calls, i.e. `s.Symbol("sym", "abc").Table("my_table").AtNow(ctx)`.
* Also updates GHA to Go 1.20