### PR TITLE
Example adjustments for doc consumption

### DIFF
--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -32,8 +32,17 @@
     port: 9009
 - name: ilp-from-conf
   lang: go
-  path: examples/http/from-conf/main.go
+  path: examples/from-conf/main.go
   header: |-
     Go client library [docs](https://pkg.go.dev/github.com/questdb/go-questdb-client/v3)
     and [repo](https://github.com/questdb/go-questdb-client).
   conf: http::addr=localhost:9000;
+- name: ilp-http-auth
+  lang: go
+  path: examples/http/auth-and-tls/main.go
+  header: |-
+    Go client library [docs](https://pkg.go.dev/github.com/questdb/go-questdb-client/v3)
+    and [repo](https://github.com/questdb/go-questdb-client).
+  auth:
+    kid: testUser1
+    d: 5UjEMuA0Pj5pjK8a-fa24dyIf-Es5mYny3oE_Wmus48

--- a/examples.manifest.yaml
+++ b/examples.manifest.yaml
@@ -37,12 +37,3 @@
     Go client library [docs](https://pkg.go.dev/github.com/questdb/go-questdb-client/v3)
     and [repo](https://github.com/questdb/go-questdb-client).
   conf: http::addr=localhost:9000;
-- name: ilp-http-auth
-  lang: go
-  path: examples/http/auth-and-tls/main.go
-  header: |-
-    Go client library [docs](https://pkg.go.dev/github.com/questdb/go-questdb-client/v3)
-    and [repo](https://github.com/questdb/go-questdb-client).
-  auth:
-    kid: testUser1
-    d: 5UjEMuA0Pj5pjK8a-fa24dyIf-Es5mYny3oE_Wmus48


### PR DESCRIPTION
Adds another example path & alters `from-conf` to match expectations.


For posterity, from docusaurus:

```
Error: Could not load code from https://raw.githubusercontent.com/questdb/go-questdb-client/main/examples/http/from-conf/main.go: Error 404
    at Object.loadContent (/Users/goodroot/Code/questdb.io/plugins/remote-repo-example/index.js:63:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/plugins/index.js:53:46
    at async Promise.all (index 6)
    at async Object.loadPlugins (/Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/plugins/index.js:52:34)
    at async Object.load (/Users/goodroot/Code/questdb.io/node_modules/@docusaurus/core/lib/server/index.js:94:82)
```