### PR TITLE
fix(client): modify config parsing behavior to match other clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Features:
 * Optimized for batch writes.
 * Supports TLS encryption and ILP authentication.
 * Automatic write retries and connection reuse for ILP over HTTP.
-* Tested against QuestDB 7.3.11 and newer versions.
+* Tested against QuestDB 7.3.10 and newer versions.
 
 New in v3:
 * Supports ILP over HTTP using the same client semantics

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -166,9 +166,8 @@ func parseConfigStr(conf string) (configData, error) {
 			KeyValuePairs: map[string]string{},
 		}
 
-		nextRune             rune
-		isEscaping           bool
-		hasTrailingSemicolon bool
+		nextRune   rune
+		isEscaping bool
 	)
 
 	schemaStr, conf, found := strings.Cut(conf, "::")
@@ -182,10 +181,8 @@ func parseConfigStr(conf string) (configData, error) {
 		return result, NewInvalidConfigStrError("'addr' key not found")
 	}
 
-	if strings.HasSuffix(conf, ";") {
-		hasTrailingSemicolon = true
-	} else {
-		conf = conf + ";" // add trailing semicolon if it doesn't exist
+	if !strings.HasSuffix(conf, ";") {
+		return result, NewInvalidConfigStrError("trailing semicolon ';' required")
 	}
 
 	keyValueStr := []rune(conf)
@@ -198,7 +195,7 @@ func parseConfigStr(conf string) (configData, error) {
 		switch rune {
 		case ';':
 			if isKey {
-				if nextRune == 0 && !hasTrailingSemicolon {
+				if nextRune == 0 {
 					return result, NewInvalidConfigStrError("unexpected end of string")
 				}
 				return result, NewInvalidConfigStrError("invalid key character ';'")

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -86,6 +86,10 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			default:
 				panic("add a case for " + k)
 			}
+		case "token_x":
+		case "token_y":
+			// Some clients require public key.
+			// But since Go sender doesn't need it, we ignore the values.
 		case "auto_flush":
 			if v == "off" {
 				senderConf.autoFlushRows = 0

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -60,7 +60,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 	}
 
 	for k, v := range data.KeyValuePairs {
-		switch strings.ToLower(k) {
+		switch k {
 		case "addr":
 			senderConf.address = v
 		case "username":

--- a/conf_test.go
+++ b/conf_test.go
@@ -54,7 +54,7 @@ func TestParserHappyCases(t *testing.T) {
 	testCases := []parseConfigTestCase{
 		{
 			name:   "http and ipv4 address",
-			config: fmt.Sprintf("http::addr=%s", addr),
+			config: fmt.Sprintf("http::addr=%s;", addr),
 			expected: qdb.ConfigData{
 				Schema: "http",
 				KeyValuePairs: map[string]string{
@@ -74,7 +74,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "tcp and address",
-			config: fmt.Sprintf("tcp::addr=%s", addr),
+			config: fmt.Sprintf("tcp::addr=%s;", addr),
 			expected: qdb.ConfigData{
 				Schema: "tcp",
 				KeyValuePairs: map[string]string{
@@ -84,7 +84,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "http and username/password",
-			config: fmt.Sprintf("http::addr=%s;username=%s;password=%s", addr, user, pass),
+			config: fmt.Sprintf("http::addr=%s;username=%s;password=%s;", addr, user, pass),
 			expected: qdb.ConfigData{
 				Schema: "http",
 				KeyValuePairs: map[string]string{
@@ -107,7 +107,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "tcp with key and user",
-			config: fmt.Sprintf("tcp::addr=%s;token=%s;username=%s", addr, token, user),
+			config: fmt.Sprintf("tcp::addr=%s;token=%s;username=%s;", addr, token, user),
 			expected: qdb.ConfigData{
 				Schema: "tcp",
 				KeyValuePairs: map[string]string{
@@ -119,7 +119,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "https with min_throughput",
-			config: fmt.Sprintf("https::addr=%s;min_throughput=%d", addr, min_throughput),
+			config: fmt.Sprintf("https::addr=%s;min_throughput=%d;", addr, min_throughput),
 			expected: qdb.ConfigData{
 				Schema: "https",
 				KeyValuePairs: map[string]string{
@@ -130,7 +130,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "https with min_throughput, init_buf_size and tls_verify=unsafe_off",
-			config: fmt.Sprintf("https::addr=%s;min_throughput=%d;init_buf_size=%d;tls_verify=unsafe_off", addr, min_throughput, 1024),
+			config: fmt.Sprintf("https::addr=%s;min_throughput=%d;init_buf_size=%d;tls_verify=unsafe_off;", addr, min_throughput, 1024),
 			expected: qdb.ConfigData{
 				Schema: "https",
 				KeyValuePairs: map[string]string{
@@ -143,7 +143,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "tcps with tls_verify=unsafe_off",
-			config: fmt.Sprintf("tcps::addr=%s;tls_verify=unsafe_off", addr),
+			config: fmt.Sprintf("tcps::addr=%s;tls_verify=unsafe_off;", addr),
 			expected: qdb.ConfigData{
 				Schema: "tcps",
 				KeyValuePairs: map[string]string{
@@ -154,7 +154,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name: "http with min_throughput, request_timeout, and retry_timeout",
-			config: fmt.Sprintf("http::addr=%s;min_throughput=%d;request_timeout=%d;retry_timeout=%d",
+			config: fmt.Sprintf("http::addr=%s;min_throughput=%d;request_timeout=%d;retry_timeout=%d;",
 				addr, min_throughput, request_timeout.Milliseconds(), retry_timeout.Milliseconds()),
 			expected: qdb.ConfigData{
 				Schema: "http",
@@ -168,24 +168,12 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "tcp with tls_verify=on",
-			config: fmt.Sprintf("tcp::addr=%s;tls_verify=on", addr),
+			config: fmt.Sprintf("tcp::addr=%s;tls_verify=on;", addr),
 			expected: qdb.ConfigData{
 				Schema: "tcp",
 				KeyValuePairs: map[string]string{
 					"addr":       addr,
 					"tls_verify": "on",
-				},
-			},
-		},
-		{
-			name:   "password with an escaped semicolon",
-			config: fmt.Sprintf("http::addr=%s;username=%s;password=pass;;word", addr, user),
-			expected: qdb.ConfigData{
-				Schema: "http",
-				KeyValuePairs: map[string]string{
-					"addr":     addr,
-					"username": user,
-					"password": "pass;word",
 				},
 			},
 		},
@@ -215,7 +203,7 @@ func TestParserHappyCases(t *testing.T) {
 		},
 		{
 			name:   "equal sign in password",
-			config: fmt.Sprintf("http::addr=%s;username=%s;password=pass=word", addr, user),
+			config: fmt.Sprintf("http::addr=%s;username=%s;password=pass=word;", addr, user),
 			expected: qdb.ConfigData{
 				Schema: "http",
 				KeyValuePairs: map[string]string{
@@ -252,11 +240,6 @@ func TestParserPathologicalCases(t *testing.T) {
 			name:                   "no address",
 			config:                 "http::",
 			expectedErrMsgContains: "'addr' key not found",
-		},
-		{
-			name:                   "unescaped semicolon in password leads to unexpected end of string",
-			config:                 "http::addr=localhost:9000;username=test;password=pass;word",
-			expectedErrMsgContains: "unexpected end of string",
 		},
 		{
 			name:                   "unescaped semicolon in password leads to invalid key character",
@@ -299,7 +282,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 	testCases := []configTestCase{
 		{
 			name: "user and token",
-			config: fmt.Sprintf("tcp::addr=%s;username=%s;token=%s",
+			config: fmt.Sprintf("tcp::addr=%s;username=%s;token=%s;",
 				addr, user, token),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithTcp(),
@@ -309,7 +292,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "init_buf_size and max_buf_size",
-			config: fmt.Sprintf("tcp::addr=%s;init_buf_size=%d;max_buf_size=%d",
+			config: fmt.Sprintf("tcp::addr=%s;init_buf_size=%d;max_buf_size=%d;",
 				addr, initBufSize, maxBufSize),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithTcp(),
@@ -320,7 +303,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "with tls",
-			config: fmt.Sprintf("tcp::addr=%s;tls_verify=on",
+			config: fmt.Sprintf("tcp::addr=%s;tls_verify=on;",
 				addr),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithTcp(),
@@ -330,7 +313,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "with tls and unsafe_off",
-			config: fmt.Sprintf("tcp::addr=%s;tls_verify=unsafe_off",
+			config: fmt.Sprintf("tcp::addr=%s;tls_verify=unsafe_off;",
 				addr),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithTcp(),
@@ -340,7 +323,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "request_timeout and retry_timeout milli conversion",
-			config: fmt.Sprintf("http::addr=%s;request_timeout=%d;retry_timeout=%d",
+			config: fmt.Sprintf("http::addr=%s;request_timeout=%d;retry_timeout=%d;",
 				addr, requestTimeout.Milliseconds(), retryTimeout.Milliseconds()),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithHttp(),
@@ -351,7 +334,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "password before username",
-			config: fmt.Sprintf("http::addr=%s;password=%s;username=%s",
+			config: fmt.Sprintf("http::addr=%s;password=%s;username=%s;",
 				addr, pass, user),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithHttp(),
@@ -361,7 +344,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "min_throughput",
-			config: fmt.Sprintf("http::addr=%s;min_throughput=%d",
+			config: fmt.Sprintf("http::addr=%s;min_throughput=%d;",
 				addr, minThroughput),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithHttp(),
@@ -371,7 +354,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "bearer token",
-			config: fmt.Sprintf("http::addr=%s;token=%s",
+			config: fmt.Sprintf("http::addr=%s;token=%s;",
 				addr, token),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithHttp(),
@@ -381,7 +364,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 		},
 		{
 			name: "auto flush",
-			config: fmt.Sprintf("http::addr=%s;auto_flush_rows=100;auto_flush_interval=1000",
+			config: fmt.Sprintf("http::addr=%s;auto_flush_rows=100;auto_flush_interval=1000;",
 				addr),
 			expectedOpts: []qdb.LineSenderOption{
 				qdb.WithHttp(),
@@ -416,48 +399,53 @@ func TestPathologicalCasesFromConf(t *testing.T) {
 		},
 		{
 			name:                   "invalid schema",
-			config:                 "foobar::addr=localhost:1111",
+			config:                 "foobar::addr=localhost:1111;",
 			expectedErrMsgContains: "invalid schema",
 		},
 		{
 			name:                   "invalid tls_verify 1",
-			config:                 "tcp::addr=localhost:1111;tls_verify=invalid",
+			config:                 "tcp::addr=localhost:1111;tls_verify=invalid;",
 			expectedErrMsgContains: "invalid tls_verify",
 		},
 		{
 			name:                   "invalid tls_verify 2",
-			config:                 "http::addr=localhost:1111;tls_verify=invalid",
+			config:                 "http::addr=localhost:1111;tls_verify=invalid;",
 			expectedErrMsgContains: "invalid tls_verify",
 		},
 		{
 			name:                   "unsupported option",
-			config:                 "tcp::addr=localhost:1111;unsupported_option=invalid",
+			config:                 "tcp::addr=localhost:1111;unsupported_option=invalid;",
 			expectedErrMsgContains: "unsupported option",
 		},
 		{
 			name:                   "invalid auto_flush",
-			config:                 "http::addr=localhost:1111;auto_flush=invalid",
+			config:                 "http::addr=localhost:1111;auto_flush=invalid;",
 			expectedErrMsgContains: "invalid auto_flush",
 		},
 		{
 			name:                   "invalid auto_flush_rows",
-			config:                 "http::addr=localhost:1111;auto_flush_rows=invalid",
+			config:                 "http::addr=localhost:1111;auto_flush_rows=invalid;",
 			expectedErrMsgContains: "invalid auto_flush_rows",
 		},
 		{
 			name:                   "invalid auto_flush_interval",
-			config:                 "http::addr=localhost:1111;auto_flush_interval=invalid",
+			config:                 "http::addr=localhost:1111;auto_flush_interval=invalid;",
 			expectedErrMsgContains: "invalid auto_flush_interval",
 		},
 		{
 			name:                   "unsupported option",
-			config:                 "http::addr=localhost:1111;unsupported_option=invalid",
+			config:                 "http::addr=localhost:1111;unsupported_option=invalid;",
 			expectedErrMsgContains: "unsupported option",
 		},
 		{
-			name:                   "Case-sensitive values",
+			name:                   "case-sensitive values",
 			config:                 "http::aDdr=localhost:9000;",
 			expectedErrMsgContains: "unsupported option",
+		},
+		{
+			name:                   "trailing semicolon required",
+			config:                 "http::addr=localhost:9000",
+			expectedErrMsgContains: "trailing semicolon",
 		},
 	}
 

--- a/conf_test.go
+++ b/conf_test.go
@@ -244,7 +244,7 @@ func TestParserPathologicalCases(t *testing.T) {
 		{
 			name:                   "unescaped semicolon in password leads to invalid key character",
 			config:                 "http::addr=localhost:9000;username=test;password=pass;word;",
-			expectedErrMsgContains: "invalid key character ';'",
+			expectedErrMsgContains: "unexpected end of",
 		},
 	}
 

--- a/conf_test.go
+++ b/conf_test.go
@@ -291,6 +291,16 @@ func TestHappyCasesFromConf(t *testing.T) {
 			},
 		},
 		{
+			name: "token_x and token_y (ignored)",
+			config: fmt.Sprintf("tcp::addr=%s;username=%s;token=%s;token_x=xyz;token_y=xyz;",
+				addr, user, token),
+			expectedOpts: []qdb.LineSenderOption{
+				qdb.WithTcp(),
+				qdb.WithAddress(addr),
+				qdb.WithAuth(user, token),
+			},
+		},
+		{
 			name: "init_buf_size and max_buf_size",
 			config: fmt.Sprintf("tcp::addr=%s;init_buf_size=%d;max_buf_size=%d;",
 				addr, initBufSize, maxBufSize),

--- a/conf_test.go
+++ b/conf_test.go
@@ -454,6 +454,11 @@ func TestPathologicalCasesFromConf(t *testing.T) {
 			config:                 "http::addr=localhost:1111;unsupported_option=invalid",
 			expectedErrMsgContains: "unsupported option",
 		},
+		{
+			name:                   "Case-sensitive values",
+			config:                 "http::aDdr=localhost:9000;",
+			expectedErrMsgContains: "unsupported option",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -100,38 +100,43 @@ func TestHttpPathologicalCasesFromConf(t *testing.T) {
 		},
 		{
 			name:        "negative init_buf_size",
-			config:      "tcp::init_buf_size=-1",
+			config:      "http::init_buf_size=-1",
 			expectedErr: "initial buffer size is negative",
 		},
 		{
 			name:        "negative max_buf_size",
-			config:      "tcp::max_buf_size=-1",
+			config:      "http::max_buf_size=-1",
 			expectedErr: "max buffer size is negative",
 		},
 		{
 			name:        "negative retry timeout",
-			config:      "tcp::retry_timeout=-1",
+			config:      "http::retry_timeout=-1",
 			expectedErr: "retry timeout is negative",
 		},
 		{
 			name:        "negative request timeout",
-			config:      "tcp::request_timeout=-1",
+			config:      "http::request_timeout=-1",
 			expectedErr: "request timeout is negative",
 		},
 		{
 			name:        "negative min throughput",
-			config:      "tcp::min_throughput=-1",
+			config:      "http::min_throughput=-1",
 			expectedErr: "min throughput is negative",
 		},
 		{
 			name:        "negative auto flush rows",
-			config:      "tcp::auto_flush_rows=-1",
+			config:      "http::auto_flush_rows=-1",
 			expectedErr: "auto flush rows is negative",
 		},
 		{
 			name:        "negative auto flush interval",
-			config:      "tcp::auto_flush_interval=-1",
+			config:      "http::auto_flush_interval=-1",
 			expectedErr: "auto flush interval is negative",
+		},
+		{
+			name:        "schema is case-sensitive",
+			config:      "hTtp::addr=localhost:1234",
+			expectedErr: "invalid schema",
 		},
 	}
 

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -56,27 +56,27 @@ func TestHttpHappyCasesFromConf(t *testing.T) {
 	testCases := []httpConfigTestCase{
 		{
 			name: "request_timeout and retry_timeout milli conversion",
-			config: fmt.Sprintf("http::addr=%s;request_timeout=%d;retry_timeout=%d",
+			config: fmt.Sprintf("http::addr=%s;request_timeout=%d;retry_timeout=%d;",
 				addr, request_timeout.Milliseconds(), retry_timeout.Milliseconds()),
 		},
 		{
 			name: "pass before user",
-			config: fmt.Sprintf("http::addr=%s;password=%s;username=%s",
+			config: fmt.Sprintf("http::addr=%s;password=%s;username=%s;",
 				addr, pass, user),
 		},
 		{
 			name: "min_throughput",
-			config: fmt.Sprintf("http::addr=%s;min_throughput=%d",
+			config: fmt.Sprintf("http::addr=%s;min_throughput=%d;",
 				addr, min_throughput),
 		},
 		{
 			name: "bearer token",
-			config: fmt.Sprintf("http::addr=%s;token=%s",
+			config: fmt.Sprintf("http::addr=%s;token=%s;",
 				addr, token),
 		},
 		{
 			name: "auto flush",
-			config: fmt.Sprintf("http::addr=%s;auto_flush_rows=100;auto_flush_interval=1000",
+			config: fmt.Sprintf("http::addr=%s;auto_flush_rows=100;auto_flush_interval=1000;",
 				addr),
 		},
 	}
@@ -95,47 +95,47 @@ func TestHttpPathologicalCasesFromConf(t *testing.T) {
 	testCases := []httpConfigTestCase{
 		{
 			name:        "basic_and_token_auth",
-			config:      "http::username=test_user;token=test_token",
+			config:      "http::username=test_user;token=test_token;",
 			expectedErr: "both basic and token",
 		},
 		{
 			name:        "negative init_buf_size",
-			config:      "http::init_buf_size=-1",
+			config:      "http::init_buf_size=-1;",
 			expectedErr: "initial buffer size is negative",
 		},
 		{
 			name:        "negative max_buf_size",
-			config:      "http::max_buf_size=-1",
+			config:      "http::max_buf_size=-1;",
 			expectedErr: "max buffer size is negative",
 		},
 		{
 			name:        "negative retry timeout",
-			config:      "http::retry_timeout=-1",
+			config:      "http::retry_timeout=-1;",
 			expectedErr: "retry timeout is negative",
 		},
 		{
 			name:        "negative request timeout",
-			config:      "http::request_timeout=-1",
+			config:      "http::request_timeout=-1;",
 			expectedErr: "request timeout is negative",
 		},
 		{
 			name:        "negative min throughput",
-			config:      "http::min_throughput=-1",
+			config:      "http::min_throughput=-1;",
 			expectedErr: "min throughput is negative",
 		},
 		{
 			name:        "negative auto flush rows",
-			config:      "http::auto_flush_rows=-1",
+			config:      "http::auto_flush_rows=-1;",
 			expectedErr: "auto flush rows is negative",
 		},
 		{
 			name:        "negative auto flush interval",
-			config:      "http::auto_flush_interval=-1",
+			config:      "http::auto_flush_interval=-1;",
 			expectedErr: "auto flush interval is negative",
 		},
 		{
 			name:        "schema is case-sensitive",
-			config:      "hTtp::addr=localhost:1234",
+			config:      "hTtp::addr=localhost:1234;",
 			expectedErr: "invalid schema",
 		},
 	}

--- a/tcp_sender_test.go
+++ b/tcp_sender_test.go
@@ -59,11 +59,11 @@ func TestTcpHappyCasesFromConf(t *testing.T) {
 	testCases := []tcpConfigTestCase{
 		{
 			name:   "addr only",
-			config: fmt.Sprintf("tcp::addr=%s", addr),
+			config: fmt.Sprintf("tcp::addr=%s;", addr),
 		},
 		{
 			name: "init_buf_size",
-			config: fmt.Sprintf("tcp::addr=%s;init_buf_size=%d",
+			config: fmt.Sprintf("tcp::addr=%s;init_buf_size=%d;",
 				addr, initBufSize),
 		},
 	}
@@ -82,52 +82,52 @@ func TestTcpPathologicalCasesFromConf(t *testing.T) {
 	testCases := []tcpConfigTestCase{
 		{
 			name:        "request_timeout",
-			config:      "tcp::request_timeout=5",
+			config:      "tcp::request_timeout=5;",
 			expectedErr: "requestTimeout setting is not available",
 		},
 		{
 			name:        "retry_timeout",
-			config:      "tcp::retry_timeout=5",
+			config:      "tcp::retry_timeout=5;",
 			expectedErr: "retryTimeout setting is not available",
 		},
 		{
 			name:        "min_throughput",
-			config:      "tcp::min_throughput=5",
+			config:      "tcp::min_throughput=5;",
 			expectedErr: "minThroughput setting is not available",
 		},
 		{
 			name:        "auto_flush_rows",
-			config:      "tcp::auto_flush_rows=5",
+			config:      "tcp::auto_flush_rows=5;",
 			expectedErr: "autoFlushRows setting is not available",
 		},
 		{
 			name:        "auto_flush_interval",
-			config:      "tcp::auto_flush_interval=5",
+			config:      "tcp::auto_flush_interval=5;",
 			expectedErr: "autoFlushInterval setting is not available",
 		},
 		{
 			name:        "tcp key but no id",
-			config:      "tcp::token=test_key",
+			config:      "tcp::token=test_key;",
 			expectedErr: "tcpKeyId is empty",
 		},
 		{
 			name:        "tcp key id but no key",
-			config:      "tcp::username=test_key_id",
+			config:      "tcp::username=test_key_id;",
 			expectedErr: "tcpKey is empty",
 		},
 		{
 			name:        "invalid private key size",
-			config:      "tcp::username=test_key_id;token=1234567890",
+			config:      "tcp::username=test_key_id;token=1234567890;",
 			expectedErr: "invalid auth key",
 		},
 		{
 			name:        "max_buf_size is set",
-			config:      "tcp::max_buf_size=1000",
+			config:      "tcp::max_buf_size=1000;",
 			expectedErr: "maxBufferSize setting is not available",
 		},
 		{
 			name:        "schema is case-sensitive",
-			config:      "tCp::addr=localhost:1234",
+			config:      "tCp::addr=localhost:1234;",
 			expectedErr: "invalid schema",
 		},
 	}

--- a/tcp_sender_test.go
+++ b/tcp_sender_test.go
@@ -125,6 +125,11 @@ func TestTcpPathologicalCasesFromConf(t *testing.T) {
 			config:      "tcp::max_buf_size=1000",
 			expectedErr: "maxBufferSize setting is not available",
 		},
+		{
+			name:        "schema is case-sensitive",
+			config:      "tCp::addr=localhost:1234",
+			expectedErr: "invalid schema",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Changes to behavior:
- Case-sensitive scheme (behavior unchanged, just added a validating test)
- Case-sensitive keys
- Require trailing semicolon