### PR TITLE
fix(client): HTTP sender retries send empty request body

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -28,7 +28,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"math/big"
 	"strconv"
@@ -120,20 +119,6 @@ func (b *buffer) writeBigInt(i *big.Int) {
 	var a [64]byte
 	s := i.Append(a[0:0], 16)
 	b.Write(s)
-}
-
-// WriteTo wraps the built-in bytes.Buffer.WriteTo method
-// and writes the contents of the buffer to the provided
-// io.Writer
-func (b *buffer) WriteTo(w io.Writer) (int64, error) {
-	n, err := b.Buffer.WriteTo(w)
-	if err != nil {
-		b.lastMsgPos -= int(n)
-		return n, err
-	}
-	b.lastMsgPos = 0
-	b.msgCount = 0
-	return n, nil
 }
 
 func (b *buffer) writeTableName(str string) error {
@@ -384,6 +369,17 @@ func (b *buffer) prepareForField() bool {
 		b.WriteByte(',')
 	}
 	return true
+}
+
+func (b *buffer) Bytes() []byte {
+	return b.Buffer.Bytes()
+}
+
+func (b *buffer) Reset() {
+	b.Buffer.Reset()
+	b.lastMsgPos = 0
+	b.msgCount = 0
+	b.resetMsgFlags()
 }
 
 func (b *buffer) DiscardPendingMsg() {

--- a/integration_test.go
+++ b/integration_test.go
@@ -132,7 +132,7 @@ func setupQuestDB0(ctx context.Context, auth ilpAuthType, setupProxy bool) (*que
 		return nil, err
 	}
 	req := testcontainers.ContainerRequest{
-		Image:          "questdb/questdb:7.3.10",
+		Image:          "questdb/questdb:7.4.2",
 		ExposedPorts:   []string{"9000/tcp", "9009/tcp"},
 		WaitingFor:     wait.ForHTTP("/").WithPort("9000"),
 		Networks:       []string{networkName},

--- a/tcp_sender.go
+++ b/tcp_sender.go
@@ -205,6 +205,9 @@ func (s *tcpLineSender) Flush(ctx context.Context) error {
 		s.conn.SetWriteDeadline(time.Time{})
 	}
 
+	// Always reset the buffer at the end of flush.
+	defer s.buf.Reset()
+
 	if _, err := s.buf.WriteTo(s.conn); err != nil {
 		return err
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,11 +44,12 @@ import (
 type serverType int64
 
 const (
-	sendToBackChannel serverType = 0
-	readAndDiscard    serverType = 1
-	returning500      serverType = 2
-	returning403      serverType = 3
-	returning404      serverType = 4
+	sendToBackChannel              serverType = 0
+	readAndDiscard                 serverType = 1
+	returning500                   serverType = 2
+	returning403                   serverType = 3
+	returning404                   serverType = 4
+	failFirstThenSendToBackChannel serverType = 5
 )
 
 type testServer struct {
@@ -186,21 +188,21 @@ func (s *testServer) serveHttp() {
 		}
 	}()
 
+	var reqs int64
 	http.Serve(s.tcpListener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var (
 			err error
 		)
 
 		switch s.serverType {
-		case sendToBackChannel:
-			r := bufio.NewReader(r.Body)
-			var l string
-			for err == nil {
-				l, err = r.ReadString('\n')
-				if err == nil && len(l) > 0 {
-					lineFeed <- l[0 : len(l)-1]
-				}
+		case failFirstThenSendToBackChannel:
+			if atomic.AddInt64(&reqs, 1) == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else {
+				err = readAndSendToBackChannel(r, lineFeed)
 			}
+		case sendToBackChannel:
+			err = readAndSendToBackChannel(r, lineFeed)
 		case readAndDiscard:
 			_, err = io.Copy(io.Discard, r.Body)
 		case returning500:
@@ -230,6 +232,21 @@ func (s *testServer) serveHttp() {
 			}
 		}
 	}))
+}
+
+func readAndSendToBackChannel(r *http.Request, lineFeed chan string) error {
+	read := bufio.NewReader(r.Body)
+	var (
+		l   string
+		err error
+	)
+	for err == nil {
+		l, err = read.ReadString('\n')
+		if err == nil && len(l) > 0 {
+			lineFeed <- l[0 : len(l)-1]
+		}
+	}
+	return err
 }
 
 func (s *testServer) Close() {


### PR DESCRIPTION
Also changes the following:
* Buffer is now reset on any network send in Flush calls (explicit and implicit). That's to prevent potential ILP message corruption
* HTTP sender now sends non-chunked request body