### PR TITLE
fix(client): fix auto_flush_interval units in LineSenderFromConf

### DIFF
--- a/conf_parse.go
+++ b/conf_parse.go
@@ -116,7 +116,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			if err != nil {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q is not a valid int", k, v)
 			}
-			senderConf.autoFlushInterval = time.Duration(parsedVal)
+			senderConf.autoFlushInterval = time.Duration(parsedVal) * time.Millisecond
 		case "min_throughput", "init_buf_size", "max_buf_size":
 			parsedVal, err := strconv.Atoi(v)
 			if err != nil {
@@ -138,7 +138,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			if err != nil {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q is not a valid int", k, v)
 			}
-			timeoutDur := time.Duration(timeout * int(time.Millisecond))
+			timeoutDur := time.Duration(timeout) * time.Millisecond
 
 			switch k {
 			case "request_timeout":

--- a/conf_test.go
+++ b/conf_test.go
@@ -400,7 +400,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 				qdb.WithHttp(),
 				qdb.WithAddress(addr),
 				qdb.WithAutoFlushRows(100),
-				qdb.WithAutoFlushInterval(1000),
+				qdb.WithAutoFlushInterval(1000 * time.Millisecond),
 			},
 		},
 		{
@@ -422,7 +422,7 @@ func TestHappyCasesFromConf(t *testing.T) {
 				qdb.WithHttp(),
 				qdb.WithAddress(addr),
 				qdb.WithAutoFlushRows(0),
-				qdb.WithAutoFlushInterval(1000),
+				qdb.WithAutoFlushInterval(1000 * time.Millisecond),
 			},
 		},
 	}

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -462,13 +462,8 @@ func TestTimeBasedAutoFlushWithRowBasedFlushDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	defer srv.Close()
 
-	sender, err := qdb.NewLineSender(
-		ctx,
-		qdb.WithHttp(),
-		qdb.WithAddress(srv.Addr()),
-		qdb.WithAutoFlushRows(0),
-		qdb.WithAutoFlushInterval(autoFlushInterval),
-	)
+	sender, err := qdb.LineSenderFromConf(ctx,
+		fmt.Sprintf("http::addr=%s;auto_flush_rows=off;auto_flush_interval=%d;", srv.Addr(), autoFlushInterval.Milliseconds()))
 	assert.NoError(t, err)
 	defer sender.Close(ctx)
 
@@ -494,13 +489,8 @@ func TestRowBasedAutoFlushWithTimeBasedFlushDisabled(t *testing.T) {
 	assert.NoError(t, err)
 	defer srv.Close()
 
-	sender, err := qdb.NewLineSender(
-		ctx,
-		qdb.WithHttp(),
-		qdb.WithAddress(srv.Addr()),
-		qdb.WithAutoFlushRows(autoFlushRows),
-		qdb.WithAutoFlushInterval(0),
-	)
+	sender, err := qdb.LineSenderFromConf(ctx,
+		fmt.Sprintf("http::addr=%s;auto_flush_rows=%d;auto_flush_interval=off;", srv.Addr(), autoFlushRows))
 	assert.NoError(t, err)
 	defer sender.Close(ctx)
 

--- a/sender.go
+++ b/sender.go
@@ -441,7 +441,7 @@ func LineSenderFromEnv(ctx context.Context) (LineSender, error) {
 // token:                  bearer token auth (used instead of basic authentication)
 // auto_flush:             determines if auto-flushing is enabled (values "on" or "off", defaults to "on")
 // auto_flush_rows:        auto-flushing is triggered above this row count (defaults to 75000). If set, explicitly implies auto_flush=on. Set to 'off' to disable.
-//auto_flush_interval        auto-flushing is triggered above this time (defaults to 1000 milliseconds). If set, explicitly implies auto_flush=on. Set to 'off' to disable.
+// auto_flush_interval:    auto-flushing is triggered above this time, in milliseconds (defaults to 1000 milliseconds). If set, explicitly implies auto_flush=on. Set to 'off' to disable.
 // request_min_throughput: bytes per second, used to calculate each request's timeout (defaults to 100KiB/s)
 // request_timeout:        minimum request timeout in milliseconds (defaults to 10 seconds)
 // retry_timeout:          cumulative maximum millisecond duration spent in retries (defaults to 10 seconds)


### PR DESCRIPTION
The `auto_flush_interval` unit was nanos while should be millis.

Also improves HTTP sender tests.