### PR TITLE
chore(ci): fix haproxy configuration for docker v23+

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -192,7 +192,7 @@ func setupQuestDB0(ctx context.Context, auth ilpAuthType, setupProxy bool) (*que
 	)
 	if setupProxy || auth == httpBasicAuth || auth == httpBearerAuth {
 		req = testcontainers.ContainerRequest{
-			Image:        "haproxy:2.6.0",
+			Image:        "haproxy:2.6.4",
 			ExposedPorts: []string{"8443/tcp", "8444/tcp", "8445/tcp", "8888/tcp"},
 			WaitingFor:   wait.ForHTTP("/").WithPort("8888"),
 			Networks:     []string{networkName},

--- a/test/haproxy.cfg
+++ b/test/haproxy.cfg
@@ -1,3 +1,6 @@
+global
+    maxconn 256
+
 frontend httpfront
     bind 0.0.0.0:8888
     mode http
@@ -26,4 +29,3 @@ frontend httpbasicauthfront
     mode http
     http-request auth unless { http_auth(httpcreds) }
     default_backend http
-


### PR DESCRIPTION
I hit [this issue](https://github.com/haproxy/haproxy/issues/2043) when running unit tests locally.

This PR adds a global maxconn and bumps haproxy from 2.6.0 -> 2.6.4 to prevent the issue.