### PR TITLE
fix(conf): disable auto_flush when set to off in config

### DIFF
--- a/conf_parse.go
+++ b/conf_parse.go
@@ -90,16 +90,17 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		case "token_y":
 			// Some clients require public key.
 			// But since Go sender doesn't need it, we ignore the values.
+			continue
 		case "auto_flush":
 			if v == "off" {
-				senderConf.autoFlushRows = 0
-				senderConf.autoFlushInterval = 0
+				senderConf.disableAutoFlushRows = true
+				senderConf.disableAutoFlushInterval = true
 			} else if v != "on" {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q is not 'on' or 'off'", k, v)
 			}
 		case "auto_flush_rows":
 			if v == "off" {
-				senderConf.autoFlushRows = 0
+				senderConf.disableAutoFlushRows = true
 				continue
 			}
 			parsedVal, err := strconv.Atoi(v)
@@ -109,7 +110,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			senderConf.autoFlushRows = parsedVal
 		case "auto_flush_interval":
 			if v == "off" {
-				senderConf.autoFlushInterval = 0
+				senderConf.disableAutoFlushInterval = true
 				continue
 			}
 			parsedVal, err := strconv.Atoi(v)

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -90,17 +90,16 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		case "token_y":
 			// Some clients require public key.
 			// But since Go sender doesn't need it, we ignore the values.
-			continue
 		case "auto_flush":
 			if v == "off" {
-				senderConf.disableAutoFlushRows = true
-				senderConf.disableAutoFlushInterval = true
+				senderConf.autoFlushRows = 0
+				senderConf.autoFlushInterval = 0
 			} else if v != "on" {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q is not 'on' or 'off'", k, v)
 			}
 		case "auto_flush_rows":
 			if v == "off" {
-				senderConf.disableAutoFlushRows = true
+				senderConf.autoFlushRows = 0
 				continue
 			}
 			parsedVal, err := strconv.Atoi(v)
@@ -110,7 +109,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			senderConf.autoFlushRows = parsedVal
 		case "auto_flush_interval":
 			if v == "off" {
-				senderConf.disableAutoFlushInterval = true
+				senderConf.autoFlushInterval = 0
 				continue
 			}
 			parsedVal, err := strconv.Atoi(v)

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -90,6 +90,7 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		case "token_y":
 			// Some clients require public key.
 			// But since Go sender doesn't need it, we ignore the values.
+			continue
 		case "auto_flush":
 			if v == "off" {
 				senderConf.autoFlushRows = 0

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -37,7 +37,7 @@ type configData struct {
 }
 
 func confFromStr(conf string) (*lineSenderConfig, error) {
-	senderConf := &lineSenderConfig{}
+	var senderConf *lineSenderConfig
 
 	data, err := parseConfigStr(conf)
 	if err != nil {
@@ -46,14 +46,14 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 
 	switch data.Schema {
 	case "http":
-		senderConf.senderType = httpSenderType
+		senderConf = newLineSenderConfig(httpSenderType)
 	case "https":
-		senderConf.senderType = httpSenderType
+		senderConf = newLineSenderConfig(httpSenderType)
 		senderConf.tlsMode = tlsEnabled
 	case "tcp":
-		senderConf.senderType = tcpSenderType
+		senderConf = newLineSenderConfig(tcpSenderType)
 	case "tcps":
-		senderConf.senderType = tcpSenderType
+		senderConf = newLineSenderConfig(tcpSenderType)
 		senderConf.tlsMode = tlsEnabled
 	default:
 		return nil, fmt.Errorf("invalid schema: %s", data.Schema)

--- a/conf_test.go
+++ b/conf_test.go
@@ -432,7 +432,15 @@ func TestHappyCasesFromConf(t *testing.T) {
 			actual, err := qdb.ConfFromStr(tc.config)
 			assert.NoError(t, err)
 
-			expected := &qdb.LineSenderConfig{}
+			var expected *qdb.LineSenderConfig
+			switch tc.config[0] {
+			case 'h':
+				expected = qdb.NewLineSenderConfig(qdb.HttpSenderType)
+			case 't':
+				expected = qdb.NewLineSenderConfig(qdb.TcpSenderType)
+			default:
+				assert.FailNow(t, "happy case configs must start with either 'http' or 'tcp'")
+			}
 			for _, opt := range tc.expectedOpts {
 				opt(expected)
 			}

--- a/export_test.go
+++ b/export_test.go
@@ -33,10 +33,12 @@ type (
 )
 
 var (
-	GlobalTransport            = globalTransport
-	NoSenderType    SenderType = noSenderType
-	HttpSenderType  SenderType = httpSenderType
-	TcpSenderType   SenderType = tcpSenderType
+	GlobalTransport                     = globalTransport
+	NoSenderType             SenderType = noSenderType
+	HttpSenderType           SenderType = httpSenderType
+	TcpSenderType            SenderType = tcpSenderType
+	DefaultAutoFlushInterval            = defaultAutoFlushInterval
+	DefaultAutoFlushRows                = defaultAutoFlushRows
 )
 
 func NewBuffer(initBufSize int, maxBufSize int, fileNameLimit int) Buffer {

--- a/export_test.go
+++ b/export_test.go
@@ -29,10 +29,14 @@ type (
 	ConfigData       = configData
 	TcpLineSender    = tcpLineSender
 	LineSenderConfig = lineSenderConfig
+	SenderType       = senderType
 )
 
 var (
-	GlobalTransport = globalTransport
+	GlobalTransport            = globalTransport
+	NoSenderType    SenderType = noSenderType
+	HttpSenderType  SenderType = httpSenderType
+	TcpSenderType   SenderType = tcpSenderType
 )
 
 func NewBuffer(initBufSize int, maxBufSize int, fileNameLimit int) Buffer {
@@ -75,4 +79,8 @@ func BufLen(s LineSender) int {
 		return ts.BufLen()
 	}
 	panic("unexpected struct")
+}
+
+func NewLineSenderConfig(t SenderType) *LineSenderConfig {
+	return newLineSenderConfig(t)
 }

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -502,6 +502,12 @@ func TestRowBasedAutoFlushWithTimeBasedFlushDisabled(t *testing.T) {
 
 	assert.Equal(t, autoFlushRows-1, qdb.MsgCount(sender))
 
+	// Sleep past the default interval
+	time.Sleep(qdb.DefaultAutoFlushInterval + time.Millisecond)
+
+	// Check that the number of messages hasn't changed
+	assert.Equal(t, autoFlushRows-1, qdb.MsgCount(sender))
+
 	// Send one additional message and ensure that all are flushed
 	err = sender.Table(testTable).StringColumn("bar", "baz").AtNow(ctx)
 	assert.NoError(t, err)
@@ -511,8 +517,6 @@ func TestRowBasedAutoFlushWithTimeBasedFlushDisabled(t *testing.T) {
 
 func TestNoFlushWhenAutoFlushDisabled(t *testing.T) {
 	ctx := context.Background()
-	autoFlushRows := 10
-	autoFlushInterval := time.Duration(autoFlushRows-1) * time.Millisecond
 
 	srv, err := newTestHttpServer(readAndDiscard)
 	assert.NoError(t, err)
@@ -524,21 +528,54 @@ func TestNoFlushWhenAutoFlushDisabled(t *testing.T) {
 		ctx,
 		qdb.WithHttp(),
 		qdb.WithAddress(srv.Addr()),
-		qdb.WithAutoFlushRows(autoFlushRows),
-		qdb.WithAutoFlushInterval(autoFlushInterval),
+		qdb.WithAutoFlushRows(qdb.DefaultAutoFlushRows),
+		qdb.WithAutoFlushInterval(qdb.DefaultAutoFlushInterval),
 		qdb.WithAutoFlushDisabled(),
 	)
 	assert.NoError(t, err)
 	defer sender.Close(ctx)
 
 	// Send autoFlushRows + 1 messages and ensure all are buffered
-	for i := 0; i < autoFlushRows+1; i++ {
+	for i := 0; i < qdb.DefaultAutoFlushRows+1; i++ {
 		err = sender.Table(testTable).StringColumn("bar", "baz").AtNow(ctx)
 		assert.NoError(t, err)
-		time.Sleep(time.Millisecond)
 	}
 
-	assert.Equal(t, autoFlushRows+1, qdb.MsgCount(sender))
+	// Sleep past the default interval
+	time.Sleep(qdb.DefaultAutoFlushInterval + time.Millisecond)
+
+	assert.Equal(t, qdb.DefaultAutoFlushRows+1, qdb.MsgCount(sender))
+}
+
+func TestNoFlushWhenAutoFlushRowsAndIntervalAre0(t *testing.T) {
+	ctx := context.Background()
+
+	srv, err := newTestHttpServer(readAndDiscard)
+	assert.NoError(t, err)
+	defer srv.Close()
+
+	// opts are processed sequentially, so AutoFlushDisabled will
+	// override AutoFlushRows
+	sender, err := qdb.NewLineSender(
+		ctx,
+		qdb.WithHttp(),
+		qdb.WithAddress(srv.Addr()),
+		qdb.WithAutoFlushRows(0),
+		qdb.WithAutoFlushInterval(0),
+	)
+	assert.NoError(t, err)
+	defer sender.Close(ctx)
+
+	// Send autoFlushRows + 1 messages and ensure all are buffered
+	for i := 0; i < qdb.DefaultAutoFlushRows+1; i++ {
+		err = sender.Table(testTable).StringColumn("bar", "baz").AtNow(ctx)
+		assert.NoError(t, err)
+	}
+
+	// Sleep past the default interval
+	time.Sleep(qdb.DefaultAutoFlushInterval + time.Millisecond)
+
+	assert.Equal(t, qdb.DefaultAutoFlushRows+1, qdb.MsgCount(sender))
 }
 
 func TestSenderDoubleClose(t *testing.T) {

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -625,7 +625,7 @@ func TestNoFlushWhenSenderIsClosedAndAutoFlushIsDisabled(t *testing.T) {
 
 	err = sender.Close(ctx)
 	assert.NoError(t, err)
-	assert.Empty(t, qdb.Messages(sender))
+	assert.NotEmpty(t, qdb.Messages(sender))
 }
 
 func TestSuccessAfterRetries(t *testing.T) {

--- a/sender.go
+++ b/sender.go
@@ -218,6 +218,7 @@ func newLineSenderConfig(t senderType) *lineSenderConfig {
 			fileNameLimit: defaultFileNameLimit,
 		}
 	case httpSenderType:
+	default:
 		return &lineSenderConfig{
 			senderType:        t,
 			address:           defaultHttpAddress,
@@ -230,8 +231,6 @@ func newLineSenderConfig(t senderType) *lineSenderConfig {
 			maxBufSize:        defaultMaxBufferSize,
 			fileNameLimit:     defaultFileNameLimit,
 		}
-	default:
-		return &lineSenderConfig{}
 	}
 
 }
@@ -511,8 +510,9 @@ func LineSenderFromConf(ctx context.Context, conf string) (LineSender, error) {
 func NewLineSender(ctx context.Context, opts ...LineSenderOption) (LineSender, error) {
 	var conf *lineSenderConfig
 
-	// Iterate over all options to introspect the sender type
-	// This is used to set defaults based on the type of sender
+	// Iterate over all options to determine the sender type
+	// This is used to set defaults based on the type of sender (http vs tcp)
+	// Worst case performance is 2N for the number of LineSenderOptions
 	tmp := newLineSenderConfig(noSenderType)
 	for _, opt := range opts {
 		opt(tmp)

--- a/sender.go
+++ b/sender.go
@@ -217,7 +217,6 @@ func newLineSenderConfig(t senderType) *lineSenderConfig {
 			initBufSize:   defaultInitBufferSize,
 			fileNameLimit: defaultFileNameLimit,
 		}
-	case httpSenderType:
 	default:
 		return &lineSenderConfig{
 			senderType:        t,

--- a/sender.go
+++ b/sender.go
@@ -204,8 +204,10 @@ type lineSenderConfig struct {
 	httpToken string
 
 	// Auto-flush fields
-	autoFlushRows     int
-	autoFlushInterval time.Duration
+	disableAutoFlushRows     bool
+	autoFlushRows            int
+	disableAutoFlushInterval bool
+	autoFlushInterval        time.Duration
 }
 
 // LineSenderOption defines line sender config option.
@@ -384,6 +386,9 @@ func WithAutoFlushDisabled() LineSenderOption {
 func WithAutoFlushRows(rows int) LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.autoFlushRows = rows
+		if rows == 0 {
+			s.disableAutoFlushRows = true
+		}
 	}
 }
 
@@ -394,6 +399,9 @@ func WithAutoFlushRows(rows int) LineSenderOption {
 func WithAutoFlushInterval(interval time.Duration) LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.autoFlushInterval = interval
+		if interval == 0 {
+			s.disableAutoFlushInterval = true
+		}
 	}
 }
 
@@ -590,6 +598,14 @@ func sanitizeHttpConf(conf *lineSenderConfig) error {
 	}
 	if conf.fileNameLimit == 0 {
 		conf.fileNameLimit = defaultFileNameLimit
+	}
+
+	// Disable auto flush if specified in the conf
+	if conf.disableAutoFlushRows {
+		conf.autoFlushRows = 0
+	}
+	if conf.disableAutoFlushInterval {
+		conf.autoFlushInterval = 0
 	}
 
 	return nil

--- a/sender.go
+++ b/sender.go
@@ -204,10 +204,8 @@ type lineSenderConfig struct {
 	httpToken string
 
 	// Auto-flush fields
-	disableAutoFlushRows     bool
-	autoFlushRows            int
-	disableAutoFlushInterval bool
-	autoFlushInterval        time.Duration
+	autoFlushRows     int
+	autoFlushInterval time.Duration
 }
 
 // LineSenderOption defines line sender config option.
@@ -386,9 +384,6 @@ func WithAutoFlushDisabled() LineSenderOption {
 func WithAutoFlushRows(rows int) LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.autoFlushRows = rows
-		if rows == 0 {
-			s.disableAutoFlushRows = true
-		}
 	}
 }
 
@@ -399,9 +394,6 @@ func WithAutoFlushRows(rows int) LineSenderOption {
 func WithAutoFlushInterval(interval time.Duration) LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.autoFlushInterval = interval
-		if interval == 0 {
-			s.disableAutoFlushInterval = true
-		}
 	}
 }
 
@@ -598,14 +590,6 @@ func sanitizeHttpConf(conf *lineSenderConfig) error {
 	}
 	if conf.fileNameLimit == 0 {
 		conf.fileNameLimit = defaultFileNameLimit
-	}
-
-	// Disable auto flush if specified in the conf
-	if conf.disableAutoFlushRows {
-		conf.autoFlushRows = 0
-	}
-	if conf.disableAutoFlushInterval {
-		conf.autoFlushInterval = 0
 	}
 
 	return nil

--- a/sender.go
+++ b/sender.go
@@ -208,32 +208,6 @@ type lineSenderConfig struct {
 	autoFlushInterval time.Duration
 }
 
-func newLineSenderConfig(t senderType) *lineSenderConfig {
-	switch t {
-	case tcpSenderType:
-		return &lineSenderConfig{
-			senderType:    t,
-			address:       defaultTcpAddress,
-			initBufSize:   defaultInitBufferSize,
-			fileNameLimit: defaultFileNameLimit,
-		}
-	default:
-		return &lineSenderConfig{
-			senderType:        t,
-			address:           defaultHttpAddress,
-			requestTimeout:    defaultRequestTimeout,
-			retryTimeout:      defaultRetryTimeout,
-			minThroughput:     defaultMinThroughput,
-			autoFlushRows:     defaultAutoFlushRows,
-			autoFlushInterval: defaultAutoFlushInterval,
-			initBufSize:       defaultInitBufferSize,
-			maxBufSize:        defaultMaxBufferSize,
-			fileNameLimit:     defaultFileNameLimit,
-		}
-	}
-
-}
-
 // LineSenderOption defines line sender config option.
 type LineSenderOption func(*lineSenderConfig)
 
@@ -535,6 +509,31 @@ func NewLineSender(ctx context.Context, opts ...LineSenderOption) (LineSender, e
 		opt(conf)
 	}
 	return newLineSender(ctx, conf)
+}
+
+func newLineSenderConfig(t senderType) *lineSenderConfig {
+	switch t {
+	case tcpSenderType:
+		return &lineSenderConfig{
+			senderType:    t,
+			address:       defaultTcpAddress,
+			initBufSize:   defaultInitBufferSize,
+			fileNameLimit: defaultFileNameLimit,
+		}
+	default:
+		return &lineSenderConfig{
+			senderType:        t,
+			address:           defaultHttpAddress,
+			requestTimeout:    defaultRequestTimeout,
+			retryTimeout:      defaultRetryTimeout,
+			minThroughput:     defaultMinThroughput,
+			autoFlushRows:     defaultAutoFlushRows,
+			autoFlushInterval: defaultAutoFlushInterval,
+			initBufSize:       defaultInitBufferSize,
+			maxBufSize:        defaultMaxBufferSize,
+			fileNameLimit:     defaultFileNameLimit,
+		}
+	}
 }
 
 func newLineSender(ctx context.Context, conf *lineSenderConfig) (LineSender, error) {


### PR DESCRIPTION
Fixes the implicit behavior of disabling `auto_flush_rows` and `auto_flush_interval` when set to 0.

This behavior exists in the sender, but any user-configured `0` values get overridden by the sender constructor. This is a problem because we assume `0` to mean `off`, so there's no way for a user to actually disable this behavior.

Here's where we skip flushing on `0`:
- auto_flush_rows: https://github.com/questdb/go-questdb-client/blob/15324722dd7f6002ccdd03629020269eb13e48bc/buffer.go#L569
- auto_flush_interval: https://github.com/questdb/go-questdb-client/blob/15324722dd7f6002ccdd03629020269eb13e48bc/http_sender.go#L237 and https://github.com/questdb/go-questdb-client/blob/15324722dd7f6002ccdd03629020269eb13e48bc/http_sender.go#L329

I decided to add explicit bools to the config instead of dealing with nil values