### PR TITLE
feat(client): blocking LineSenderPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Golang client for QuestDB's [Influx Line Protocol](https://questdb.io/docs/refer
 The library requires Go 1.19 or newer.
 
 Features:
-* Context-aware API.
+* [Context](https://www.digitalocean.com/community/tutorials/how-to-use-contexts-in-go)-aware API.
 * Optimized for batch writes.
 * Supports TLS encryption and ILP authentication.
 * Automatic write retries and connection reuse for ILP over HTTP.
@@ -43,23 +43,40 @@ func main() {
 	}
 	// Make sure to close the sender on exit to release resources.
 	defer sender.Close(ctx)
+
 	// Send a few ILP messages.
-	err = sender.
-		Table("trades").
-		Symbol("name", "test_ilp1").
-		Float64Column("value", 12.4).
-		AtNow(ctx)
+	tradedTs, err := time.Parse(time.RFC3339, "2022-08-06T15:04:05.123456Z")
 	if err != nil {
 		log.Fatal(err)
 	}
 	err = sender.
-		Table("trades").
-		Symbol("name", "test_ilp2").
-		Float64Column("value", 11.4).
-		At(ctx, time.Now().UnixNano())
+		Table("trades_go").
+		Symbol("pair", "USDGBP").
+		Symbol("type", "buy").
+		Float64Column("traded_price", 0.83).
+		Float64Column("limit_price", 0.84).
+		Int64Column("qty", 100).
+		At(ctx, tradedTs)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	tradedTs, err = time.Parse(time.RFC3339, "2022-08-06T15:04:06.987654Z")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = sender.
+		Table("trades_go").
+		Symbol("pair", "GBPJPY").
+		Symbol("type", "sell").
+		Float64Column("traded_price", 135.97).
+		Float64Column("limit_price", 0.84).
+		Int64Column("qty", 400).
+		At(ctx, tradedTs)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Make sure that the messages are sent over the network.
 	err = sender.Flush(ctx)
 	if err != nil {

--- a/export_test.go
+++ b/export_test.go
@@ -64,6 +64,10 @@ func Messages(s LineSender) string {
 }
 
 func MsgCount(s LineSender) int {
+	if ps, ok := s.(*pooledSender); ok {
+		hs, _ := ps.wrapped.(*httpLineSender)
+		return hs.MsgCount()
+	}
 	if hs, ok := s.(*httpLineSender); ok {
 		return hs.MsgCount()
 	}

--- a/http_sender.go
+++ b/http_sender.go
@@ -29,7 +29,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -176,7 +175,7 @@ func (s *httpLineSender) flush0(ctx context.Context, closing bool) error {
 	)
 
 	if s.closed {
-		return errors.New("cannot flush a closed LineSender")
+		return errClosedSenderFlush
 	}
 
 	err := s.buf.LastErr()
@@ -187,7 +186,7 @@ func (s *httpLineSender) flush0(ctx context.Context, closing bool) error {
 	}
 	if s.buf.HasTable() {
 		s.buf.DiscardPendingMsg()
-		return errors.New("pending ILP message must be finalized with At or AtNow before calling Flush")
+		return errFlushWithPendingMessage
 	}
 
 	if s.buf.msgCount == 0 {
@@ -285,7 +284,7 @@ func (s *httpLineSender) BoolColumn(name string, val bool) LineSender {
 
 func (s *httpLineSender) Close(ctx context.Context) error {
 	if s.closed {
-		return errors.New("double http sender close")
+		return errDoubleSenderClose
 	}
 
 	var err error
@@ -309,7 +308,7 @@ func (s *httpLineSender) AtNow(ctx context.Context) error {
 
 func (s *httpLineSender) At(ctx context.Context, ts time.Time) error {
 	if s.closed {
-		return errors.New("cannot queue new messages on a closed LineSender")
+		return errClosedSenderAt
 	}
 
 	sendTs := true

--- a/http_sender.go
+++ b/http_sender.go
@@ -285,7 +285,7 @@ func (s *httpLineSender) BoolColumn(name string, val bool) LineSender {
 
 func (s *httpLineSender) Close(ctx context.Context) error {
 	if s.closed {
-		return nil
+		return errors.New("double http sender close")
 	}
 
 	var err error

--- a/http_sender_test.go
+++ b/http_sender_test.go
@@ -601,7 +601,7 @@ func TestSenderDoubleClose(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = sender.Close(ctx)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestErrorOnFlushWhenSenderIsClosed(t *testing.T) {

--- a/sender.go
+++ b/sender.go
@@ -35,6 +35,13 @@ import (
 	"time"
 )
 
+var (
+	errClosedSenderFlush       = errors.New("cannot flush a closed LineSender")
+	errFlushWithPendingMessage = errors.New("pending ILP message must be finalized with At or AtNow before calling Flush")
+	errClosedSenderAt          = errors.New("cannot queue new messages on a closed LineSender")
+	errDoubleSenderClose       = errors.New("double sender close")
+)
+
 // LineSender allows you to insert rows into QuestDB by sending ILP
 // messages over HTTP or TCP protocol.
 //

--- a/sender_pool.go
+++ b/sender_pool.go
@@ -191,7 +191,7 @@ func (p *LineSenderPool) Sender(ctx context.Context) (LineSender, error) {
 func (p *LineSenderPool) free(ctx context.Context, ps *pooledSender) error {
 	var flushErr error
 
-	if ps.dirty {
+	if !ps.dirty {
 		flushErr = ps.Flush(ctx)
 	}
 

--- a/sender_pool.go
+++ b/sender_pool.go
@@ -133,7 +133,7 @@ func WithMaxSenders(count int) LineSenderPoolOption {
 // Sender obtains a LineSender from the pool. If the pool is empty, a new
 // LineSender will be instantiated using the pool's config string.
 // If there is already maximum number of senders obtained from the pool,
-// this calls will block until one of the senders is returned back to
+// this call will block until one of the senders is returned back to
 // the pool by calling sender.Close().
 func (p *LineSenderPool) Sender(ctx context.Context) (LineSender, error) {
 	var (
@@ -337,7 +337,7 @@ func (ps *pooledSender) Flush(ctx context.Context) error {
 
 func (ps *pooledSender) Close(ctx context.Context) error {
 	if atomic.AddUint64(&ps.tick, 1)&1 == 1 {
-		return errors.New("double sender close")
+		return errors.New("double pooled sender close")
 	}
 	return ps.pool.free(ctx, ps)
 }

--- a/sender_pool.go
+++ b/sender_pool.go
@@ -197,6 +197,8 @@ func (p *LineSenderPool) free(ctx context.Context, ps *pooledSender) error {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	// Notify free sender waiters, if any
+	defer p.cond.Broadcast()
 
 	if flushErr != nil {
 		// Failed to flush, close and call it a day
@@ -215,8 +217,6 @@ func (p *LineSenderPool) free(ctx context.Context, ps *pooledSender) error {
 	}
 
 	p.freeSenders = append(p.freeSenders, ps)
-	// Notify free sender waiters, if any
-	p.cond.Broadcast()
 	return nil
 }
 

--- a/sender_pool.go
+++ b/sender_pool.go
@@ -202,7 +202,10 @@ func (p *LineSenderPool) free(ctx context.Context, ps *pooledSender) error {
 		// Failed to flush, close and call it a day
 		p.numSenders--
 		closeErr := ps.wrapped.Close(ctx)
-		return fmt.Errorf("%s %w", flushErr, closeErr)
+		if closeErr != nil {
+			return fmt.Errorf("%s %w", flushErr, closeErr)
+		}
+		return flushErr
 	}
 
 	if ps.dirty || p.closed {

--- a/sender_pool_test.go
+++ b/sender_pool_test.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,35 +42,35 @@ func TestBasicBehavior(t *testing.T) {
 	ctx := context.Background()
 
 	// Start with an empty pool, allocate a new sender
-	s1, err := p.Acquire(ctx)
+	s1, err := p.Sender(ctx)
 	assert.NoError(t, err)
 
 	// Release the sender and add it to the pool
-	assert.NoError(t, p.Release(ctx, s1))
+	assert.NoError(t, s1.Close(ctx))
 
 	// Acquiring a sender will return the initial one from the pool
-	s2, err := p.Acquire(ctx)
+	s2, err := p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s1, s2)
 
 	// Acquiring another sender will create a new one
-	s3, err := p.Acquire(ctx)
+	s3, err := p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.NotSame(t, s1, s3)
 
 	// Releasing the new sender will add it back to the pool
-	assert.NoError(t, p.Release(ctx, s3))
+	assert.NoError(t, s3.Close(ctx))
 
 	// Releasing the original sender will add it to the end of the pool slice
-	assert.NoError(t, p.Release(ctx, s2))
+	assert.NoError(t, s2.Close(ctx))
 
 	// Acquiring a new sender will pop the original one off the slice
-	s4, err := p.Acquire(ctx)
+	s4, err := p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s1, s4)
 
 	// Acquiring another sender will pop the second one off the slice
-	s5, err := p.Acquire(ctx)
+	s5, err := p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s3, s5)
 }
@@ -81,57 +82,80 @@ func TestDoubleReleaseShouldFail(t *testing.T) {
 	ctx := context.Background()
 
 	// Start with an empty pool, allocate a new sender
-	s1, err := p.Acquire(ctx)
+	s1, err := p.Sender(ctx)
 	assert.NoError(t, err)
 
 	// Release the sender
-	assert.NoError(t, p.Release(ctx, s1))
+	assert.NoError(t, s1.Close(ctx))
 
-	// Try to release the sender again. This should fail because it already exists in the slice
-	assert.Error(t, p.Release(ctx, s1))
+	// Try to release the sender again. This should fail
+	assert.Error(t, s1.Close(ctx))
 }
 
 func TestMaxPoolSize(t *testing.T) {
 	// Create a pool with 2 max senders
-	p, err := questdb.PoolFromConf("http::addr=localhost:1234", questdb.WithMaxSenders(2))
+	p, err := questdb.PoolFromConf("http::addr=localhost:1234", questdb.WithMaxSenders(3))
 	require.NoError(t, err)
 
 	ctx := context.Background()
 
 	// Allocate 3 senders
-	s1, err := p.Acquire(ctx)
+	s1, err := p.Sender(ctx)
 	assert.NoError(t, err)
 
-	s2, err := p.Acquire(ctx)
+	s2, err := p.Sender(ctx)
 	assert.NoError(t, err)
 
-	s3, err := p.Acquire(ctx)
+	s3, err := p.Sender(ctx)
 	assert.NoError(t, err)
 
 	// Release all senders in reverse order
 	// Internal slice will look like: [ s3 , s2 ]
-	assert.NoError(t, p.Release(ctx, s3))
-	assert.NoError(t, p.Release(ctx, s2))
-	assert.NoError(t, p.Release(ctx, s1))
+	assert.NoError(t, s3.Close(ctx))
+	assert.NoError(t, s2.Close(ctx))
+	assert.NoError(t, s1.Close(ctx))
 
 	// Acquire 3 more senders.
 
-	// The first one will be s2 (senders get popped off the slice)
-	s, err := p.Acquire(ctx)
+	// The first one will be s3 (senders get popped off the slice)
+	s, err := p.Sender(ctx)
+	assert.NoError(t, err)
+	assert.Same(t, s, s1)
+
+	// The next will be s2
+	s, err = p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s, s2)
 
-	// The next will be s3
-	s, err = p.Acquire(ctx)
+	// The final one will s1
+	s, err = p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s, s3)
 
-	// The final one will not be s1, s2, or s3 because the slice is empty
-	s, err = p.Acquire(ctx)
-	assert.NoError(t, err)
-	assert.NotSame(t, s, s1)
-	assert.NotSame(t, s, s2)
-	assert.NotSame(t, s, s3)
+	// Now verify the Sender caller gets blocked until a sender is freed
+	successFlag := int64(0)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		s, err := p.Sender(ctx)
+		assert.NoError(t, err)
+		atomic.AddInt64(&successFlag, 1)
+		assert.Same(t, s, s3)
+		assert.NoError(t, s.Close(ctx))
+		wg.Done()
+	}()
+
+	assert.Equal(t, atomic.LoadInt64(&successFlag), int64(0))
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, atomic.LoadInt64(&successFlag), int64(0))
+
+	assert.NoError(t, s3.Close(ctx))
+	wg.Wait()
+	assert.Equal(t, atomic.LoadInt64(&successFlag), int64(1))
+
+	assert.NoError(t, s2.Close(ctx))
+	assert.NoError(t, s1.Close(ctx))
+	assert.NoError(t, p.Close(ctx))
 }
 
 func TestMultiThreadedPoolWritesOverHttp(t *testing.T) {
@@ -154,12 +178,12 @@ func TestMultiThreadedPoolWritesOverHttp(t *testing.T) {
 		i := i
 		wg.Add(1)
 		go func() {
-			sender, err := pool.Acquire(ctx)
+			sender, err := pool.Sender(ctx)
 			assert.NoError(t, err)
 
 			sender.Table("test").Int64Column("thread", int64(i)).AtNow(ctx)
 
-			assert.NoError(t, pool.Release(ctx, sender))
+			assert.NoError(t, sender.Close(ctx))
 
 			wg.Done()
 		}()

--- a/sender_pool_test.go
+++ b/sender_pool_test.go
@@ -31,14 +31,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/questdb/go-questdb-client/v3"
 	qdb "github.com/questdb/go-questdb-client/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBasicBehavior(t *testing.T) {
-	p, err := questdb.PoolFromConf("http::addr=localhost:1234")
+	p, err := qdb.PoolFromConf("http::addr=localhost:1234")
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -83,7 +82,7 @@ func TestFlushOnClose(t *testing.T) {
 	assert.NoError(t, err)
 	defer srv.Close()
 
-	p, err := questdb.PoolFromOptions(
+	p, err := qdb.PoolFromOptions(
 		qdb.WithHttp(),
 		qdb.WithAddress(srv.Addr()),
 		qdb.WithAutoFlushDisabled(),
@@ -105,7 +104,7 @@ func TestFlushOnClose(t *testing.T) {
 }
 
 func TestPooledSenderDoubleClose(t *testing.T) {
-	p, err := questdb.PoolFromConf("http::addr=localhost:1234")
+	p, err := qdb.PoolFromConf("http::addr=localhost:1234")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -123,7 +122,7 @@ func TestPooledSenderDoubleClose(t *testing.T) {
 
 func TestMaxPoolSize(t *testing.T) {
 	// Create a pool with 2 max senders
-	p, err := questdb.PoolFromConf("http::addr=localhost:1234", questdb.WithMaxSenders(3))
+	p, err := qdb.PoolFromConf("http::addr=localhost:1234", qdb.WithMaxSenders(3))
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -200,7 +199,7 @@ func TestMultiThreadedPoolWritesOverHttp(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 
-	pool, err := questdb.PoolFromConf(fmt.Sprintf("http::addr=%s", srv.Addr()), questdb.WithMaxSenders(maxSenders))
+	pool, err := qdb.PoolFromConf(fmt.Sprintf("http::addr=%s", srv.Addr()), qdb.WithMaxSenders(maxSenders))
 	require.NoError(t, err)
 
 	for i := 0; i < numThreads; i++ {
@@ -243,9 +242,9 @@ func TestMultiThreadedPoolWritesOverHttp(t *testing.T) {
 }
 
 func TestTcpNotSupported(t *testing.T) {
-	_, err := questdb.PoolFromConf("tcp::addr=localhost:9000")
+	_, err := qdb.PoolFromConf("tcp::addr=localhost:9000")
 	assert.ErrorContains(t, err, "tcp/s not supported for pooled senders")
 
-	_, err = questdb.PoolFromConf("tcps::addr=localhost:9000")
+	_, err = qdb.PoolFromConf("tcps::addr=localhost:9000")
 	assert.ErrorContains(t, err, "tcp/s not supported for pooled senders")
 }

--- a/sender_pool_test.go
+++ b/sender_pool_test.go
@@ -145,7 +145,7 @@ func TestMaxPoolSize(t *testing.T) {
 
 	// Acquire 3 more senders.
 
-	// The first one will be s3 (senders get popped off the slice)
+	// The first one will be s1 (senders get popped off the slice)
 	s, err := p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s, s1)
@@ -155,7 +155,7 @@ func TestMaxPoolSize(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Same(t, s, s2)
 
-	// The final one will s1
+	// The final one will s3
 	s, err = p.Sender(ctx)
 	assert.NoError(t, err)
 	assert.Same(t, s, s3)

--- a/tcp_sender.go
+++ b/tcp_sender.go
@@ -33,7 +33,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -137,7 +136,7 @@ func newTcpLineSender(ctx context.Context, conf *lineSenderConfig) (*tcpLineSend
 
 func (s *tcpLineSender) Close(_ context.Context) error {
 	if s.conn == nil {
-		return errors.New("double tcp sender close")
+		return errDoubleSenderClose
 	}
 	conn := s.conn
 	s.conn = nil
@@ -193,7 +192,7 @@ func (s *tcpLineSender) Flush(ctx context.Context) error {
 	}
 	if s.buf.HasTable() {
 		s.buf.DiscardPendingMsg()
-		return errors.New("pending ILP message must be finalized with At or AtNow before calling Flush")
+		return errFlushWithPendingMessage
 	}
 
 	if err = ctx.Err(); err != nil {

--- a/tcp_sender.go
+++ b/tcp_sender.go
@@ -136,12 +136,12 @@ func newTcpLineSender(ctx context.Context, conf *lineSenderConfig) (*tcpLineSend
 }
 
 func (s *tcpLineSender) Close(_ context.Context) error {
-	if s.conn != nil {
-		conn := s.conn
-		s.conn = nil
-		return conn.Close()
+	if s.conn == nil {
+		return errors.New("double tcp sender close")
 	}
-	return nil
+	conn := s.conn
+	s.conn = nil
+	return conn.Close()
 }
 
 func (s *tcpLineSender) Table(name string) LineSender {

--- a/tcp_sender_test.go
+++ b/tcp_sender_test.go
@@ -207,6 +207,23 @@ func TestTcpPathologicalCasesFromConf(t *testing.T) {
 	}
 }
 
+func TestTcpSenderDoubleClose(t *testing.T) {
+	ctx := context.Background()
+
+	srv, err := newTestTcpServer(readAndDiscard)
+	assert.NoError(t, err)
+	defer srv.Close()
+
+	sender, err := qdb.NewLineSender(ctx, qdb.WithTcp(), qdb.WithAddress(srv.Addr()))
+	assert.NoError(t, err)
+
+	err = sender.Close(ctx)
+	assert.NoError(t, err)
+
+	err = sender.Close(ctx)
+	assert.Error(t, err)
+}
+
 func TestErrorOnFlushWhenMessageIsPending(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
**Breaking change of an experimental API**

The pool now blocks if there are already too many senders in use. Pooled senders are released implicitly, via the `Close` call.

```go
	sender, err := pool.Sender(ctx)
	if err != nil {
		panic(err)
	}

	// ...

	// Close call returns the sender back to the pool
	if err := sender.Close(ctx); err != nil {
		panic(err)
	}
```