### PR TITLE
refactor(qwp): consolidate the QWP connect-string configuration keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,10 +115,6 @@ cross-flush high-water mark that `resetAfterFlush` rewinds `batchMaxSymbolId` to
 full dict its rows reference. Both are also read by tests and external
 observers, but that is incidental to their wire role.
 
-`WithInFlightWindow(n)` / `in_flight_window=n` is **retained but a no-op** in
-the cursor architecture — backpressure is governed by the engine's segment-ring
-+ `engineAppendBlocking` deadline.
-
 ### Java-parity QWP knobs (not in connect-string.md)
 
 These connect-string keys are recognised by the Java client
@@ -130,7 +126,6 @@ considered for removal without a matching change in Java:
 
 - `gorilla=on|off` — gates the Gorilla timestamp encoding in
   `qwp_encoder.go` (FLAG_GORILLA). Default `on`.
-- `in_flight_window=N` — see the "retained but a no-op" note above.
 
 `close_timeout=N` (millisecond integer) was a v4.0–v4.5 Go-only key
 for the memory-mode close path. The cursor architecture unified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,15 +117,12 @@ observers, but that is incidental to their wire role.
 
 ### Java-parity QWP knobs (not in connect-string.md)
 
-These connect-string keys are recognised by the Java client
-(`Sender.java`) but are not listed in the
-[native-client spec](https://github.com/questdb/questdb-enterprise/blob/main/questdb/docs/qwp/connect-string.md).
-We accept them for Java-parity portability — a connect string that
-works on the Java client must work here. None should ever be
-considered for removal without a matching change in Java:
-
-- `gorilla=on|off` — gates the Gorilla timestamp encoding in
-  `qwp_encoder.go` (FLAG_GORILLA). Default `on`.
+There are currently no QWP connect-string keys that the Java client
+(`Sender.java`) accepts but the
+[native-client spec](https://github.com/questdb/questdb-enterprise/blob/main/questdb/docs/qwp/connect-string.md)
+omits. Any key added for Java-parity portability — a connect string
+that works on the Java client must work here — should be listed here
+and never removed without a matching change in Java.
 
 `close_timeout=N` (millisecond integer) was a v4.0–v4.5 Go-only key
 for the memory-mode close path. The cursor architecture unified

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ Go client library for QuestDB ingestion. Three transports:
 
 Module path: `github.com/questdb/go-questdb-client/v4` — the `/v4` segment is
 load-bearing when importing within this repo. Minimum Go: 1.23 (go.mod pins
-`go 1.23` with a `1.24.4` toolchain).
+`go 1.23` with no `toolchain` directive; CI's `1.23.x`/`1.24.x` matrix runs
+under `GOTOOLCHAIN=local`).
 
 ## Commands
 
@@ -88,84 +89,20 @@ encodes a batch into `qwpSfCursorEngine` via `engineAppendBlocking`; the
 `qwpSfSendLoop` goroutine drains it to the WebSocket, parses ACKs, advances
 `engineAckedFsn`, and owns reconnect + replay from `engineAckedFsn() + 1`.
 
-**Cursor frames are self-sufficient** — full schema definitions plus the full
-symbol dictionary from id 0, every flush. This is what makes
-reconnect/replay/orphan-adoption safe across a fresh server connection.
-
-**The wire carries no schema id and no schema mode byte.** A table block is
-`table_name, row_count, col_count, inline columns, column data`; the inline
-column definitions are the authoritative schema, repeated on every frame. There
-is no `nextSchemaId` accumulator on the sender, no per-table `schemaId` field on
-the table buffer, no schema-change detection, and no reference mode. (QWP once
-carried a mode byte + schema id plus a schema-reference optimisation; it was
-removed across the server and all clients.) On egress, the decoder parses the
-schema from the first `RESULT_BATCH` of a query (`batch_seq == 0`) into
-`qwpQueryDecoder.querySchema` and reuses it for that query's continuation
-batches; `qwpEgressIO.dispatcherRun` calls `resetQuerySchema` at the start of
-every query so a schema never leaks across query boundaries.
-
-Symbol-dict tracking (`maxSentSymbolId`, `batchMaxSymbolId`) is still in place,
-and both fields are load-bearing. The encoder always passes `-1` as the
-`maxSentId` arg of `encodeMultiTableWithDeltaDict` to force "full dict from id
-0", but `batchMaxSymbolId` is the separate `batchMaxId` arg and bounds the dict
-actually written: `writeDeltaDict` emits `globalDict[0..batchMaxSymbolId]`, so
-dropping it would silently truncate the symbol dict. `maxSentSymbolId` is the
-cross-flush high-water mark that `resetAfterFlush` rewinds `batchMaxSymbolId` to
-(never to `-1`), so a later batch reusing only earlier symbols still writes the
-full dict its rows reference. Both are also read by tests and external
-observers, but that is incidental to their wire role.
-
-### Java-parity QWP knobs (not in connect-string.md)
-
-There are currently no QWP connect-string keys that the Java client
-(`Sender.java`) accepts but the
-[native-client spec](https://github.com/questdb/questdb-enterprise/blob/main/questdb/docs/qwp/connect-string.md)
-omits. Any key added for Java-parity portability — a connect string
-that works on the Java client must work here — should be listed here
-and never removed without a matching change in Java.
-
-`close_timeout=N` (millisecond integer) was a v4.0–v4.5 Go-only key
-for the memory-mode close path. The cursor architecture unified
-memory and SF onto `close_flush_timeout_millis`, which the spec
-also defines. The parser now rejects `close_timeout=` with a
-migration hint pointing at `close_flush_timeout_millis`.
-`WithCloseTimeout(d)` is retained as a deprecated alias that routes
-positive durations through `close_flush_timeout_millis`; new code
-should use `WithCloseFlushTimeout` directly.
-
-Flush semantics: `Flush` / `FlushAndGetSequence` **never wait for the server
-ACK** — they return once the batch is published into the cursor engine (in-RAM
-for memory mode, on-disk for SF) and the send loop delivers + replays it in the
-background. This matches the Java spec (`design/qwp-cursor-durability.md`
-decision #1: "flush() never waits for ACK; ACKs are async") and is uniform
-across both the pending-rows and zero-pending branches and auto-flush — all
-route through `enqueueCursor`; explicit `Flush` only additionally surfaces a
-latched send-loop error eagerly. (`Flush` was an ACK barrier
-through v4.2.0; that contract was dropped when the cursor/SF architecture made
-local persistence, not the ACK, the durability guarantee.) `FlushAndGetSequence` returns the
-published FSN — the upper bound of any `SenderError.ToFsn` for that batch;
-**pair it with `AwaitAckedFsn` for server-ACK confirmation** (the dedicated
-primitive now that `Flush` no longer blocks on ACKs).
-
-Orphan-slot adoption (SF mode, `drain_orphans=on`) is implemented in
-`qwp_sf_orphan.go` + `qwp_sf_drainer.go` + `qwp_sf_round_walk.go`; drainers run
-in dedicated goroutines and are visible via `QwpSender.BackgroundDrainers()`.
+**`Flush` / `FlushAndGetSequence` never wait for the server ACK** — they return
+once the batch is published to the cursor engine (in-RAM for memory mode,
+on-disk for SF); delivery and replay to the server run in the background. For
+server-ACK confirmation, pair `FlushAndGetSequence` with `AwaitAckedFsn`.
 
 ### Error handling
 
 QWP server rejections surface as `*SenderError` (`sender_error.go` is canonical
-for categories + policy enum). Two paths: async callback registered via
-`WithErrorHandler`, and producer-side typed error via `errors.As` after `Flush`
-/ `FlushAndGetSequence`.
-
-Policy resolution precedence (highest first): `WithErrorPolicyResolver` →
-`WithErrorPolicy(category, ...)` → connect-string `on_*_error` →
-`on_server_error` → spec defaults. `PROTOCOL_VIOLATION` and `UNKNOWN` are never
-user-configurable — always HALT.
-
-A HALT latches the typed error on the I/O loop; `sendLoopCheckError()` surfaces
-it on the next producer call. The sender does not auto-resume — close + rebuild
-is the supported recovery (matches Java).
+for the categories + policy enum). `PROTOCOL_VIOLATION` and `UNKNOWN` are never
+user-configurable — always HALT. A HALT records the typed error on the I/O loop
+and surfaces it on the next producer call; the sender does not auto-resume, so
+close + rebuild is the supported recovery. Policy precedence, highest first:
+`WithErrorPolicyResolver` → `WithErrorPolicy` → connect-string `on_*_error` →
+`on_server_error` → spec defaults.
 
 ### Connection pooling
 
@@ -177,10 +114,6 @@ doesn't participate.
 
 QWP unit tests use `httptest.Server` to stand in for the QuestDB WebSocket
 endpoint (`newQwpTestServer` in `qwp_sender_test.go`). ILP unit tests are pure.
-
-`*_integration_test.go` files need Docker — they spin up real QuestDB via
-testcontainers-go; HTTP/TCP suites sometimes launch haproxy via
-`test/haproxy.cfg`.
 
 Cross-language conformance: `interop_test.go` +
 `test/interop/questdb-client-test` (submodule) — ILP vectors shared across

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ the lock releases automatically when the process exits.
 |---|---|---|
 | `sf_dir` | unset | Group root. Setting it activates SF. |
 | `sender_id` | `default` | Per-sender slot name; ASCII letters / digits / `-_.` only. |
-| `sf_max_bytes` | 4 MiB | Per-segment file size. |
+| `sf_max_segment_bytes` | 4 MiB | Per-segment file size. |
 | `sf_max_total_bytes` | 10 GiB | Total cap; producer is backpressured when reached. |
 | `sf_durability` | `memory` | Reserved; `flush` / `append` are deferred follow-ups. |
 | `sf_append_deadline_millis` | 30000 | How long `At` / `AtNow` block on backpressure before failing. |
@@ -590,7 +590,7 @@ the lock releases automatically when the process exits.
 | `max_background_drainers` | 4 | Cap on concurrent orphan drainers. |
 
 The same options are available programmatically:
-`WithSfDir`, `WithSenderId`, `WithSfMaxBytes`, `WithSfMaxTotalBytes`,
+`WithSfDir`, `WithSenderId`, `WithSfMaxSegmentBytes`, `WithSfMaxTotalBytes`,
 `WithReconnectPolicy`, `WithInitialConnectRetry`,
 `WithInitialConnectMode`, `WithCloseFlushTimeout`.
 

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ governed by the engine's segment ring and the append deadline
 (`sf_append_deadline_millis` in store-and-forward mode), not by a
 fixed in-flight count.
 
-`in_flight_window` / `qdb.WithInFlightWindow(n)` is **retained for
-backward compatibility but is a no-op** in this architecture. Connect
-strings carrying it still parse; the value is ignored.
+There is no in-flight-window knob: the cursor architecture governs
+backpressure on its own, so connect strings have no pipeline-depth key
+and an unrecognized one is rejected as an unsupported option.
 
 `Flush` and `FlushAndGetSequence` **never wait for the server ACK**.
 They return once the batch is published into the cursor engine — in

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -37,7 +37,7 @@ import (
 // transport selection as the short forms.
 func TestConfQwpwsAlias(t *testing.T) {
 	cases := []struct {
-		schema string
+		schema  string
 		wantTLS tlsMode
 	}{
 		{"ws", tlsDisabled},
@@ -131,12 +131,12 @@ func TestConfSizeSuffix(t *testing.T) {
 func TestConfSizeSuffixRejected(t *testing.T) {
 	cases := []string{
 		"",
-		"k",       // suffix without a number
-		"abc",     // non-numeric
-		"1.5m",    // floats not supported
-		"-1",      // negative bare
-		"-1m",     // negative with suffix
-		"1xb",     // unknown suffix
+		"k",            // suffix without a number
+		"abc",          // non-numeric
+		"1.5m",         // floats not supported
+		"-1",           // negative bare
+		"-1m",          // negative with suffix
+		"1xb",          // unknown suffix
 		"1024kb extra", // trailing garbage
 	}
 	for _, in := range cases {
@@ -318,6 +318,7 @@ func TestConfIngestSilentlyAcceptsEgressKeys(t *testing.T) {
 	// interpret them, so even invalid values must pass.
 	kvs := []string{
 		"buffer_pool_size=8",
+		"client_id=dashboard",
 		"compression=zstd",
 		"compression_level=22",
 		"failover=off",
@@ -327,6 +328,9 @@ func TestConfIngestSilentlyAcceptsEgressKeys(t *testing.T) {
 		"failover_max_duration_ms=60000",
 		"initial_credit=262144",
 		"max_batch_rows=10000",
+		"path=/read/v2",
+		"replay_exec=on",
+		"server_info_timeout_ms=750",
 	}
 	for _, kv := range kvs {
 		t.Run(kv, func(t *testing.T) {

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -609,17 +609,11 @@ func TestWithCloseTimeoutSubMillisecondIsNoOverride(t *testing.T) {
 	}
 }
 
-// TestConfQwpIngressAcceptsExtraIngressKeys pins that the ingress-only
-// QWP keys the Java client (Sender.java) accepts but the doc Key index
-// omits — transaction, connection_listener_inbox_capacity — parse on the
-// QWP ingress sender. This client implements neither feature, so they are
-// validated no-ops; accepting them is what lets a connect string shared
-// with a transaction-aware client still load here. The UDP-only keys
-// max_datagram_size / multicast_ttl are excluded: QWP rejects them (see
-// TestConfQwpRejectsUdpKeys).
+// TestConfQwpIngressAcceptsExtraIngressKeys pins that the supported
+// values of ingress-only QWP keys the Java client accepts but the doc
+// Key index omits parse on the QWP ingress sender.
 func TestConfQwpIngressAcceptsExtraIngressKeys(t *testing.T) {
 	kvs := []string{
-		"transaction=on",
 		"transaction=off",
 		"connection_listener_inbox_capacity=64",
 	}
@@ -628,6 +622,23 @@ func TestConfQwpIngressAcceptsExtraIngressKeys(t *testing.T) {
 			conf := "ws::addr=localhost:9000;" + kv + ";"
 			if _, err := confFromStr(conf); err != nil {
 				t.Errorf("QWP ingress rejected %q: %v", kv, err)
+			}
+		})
+	}
+}
+
+// TestConfQwpIngressRejectsTransactionOn ensures callers cannot request
+// transactional ingestion and silently receive ordinary writes while
+// transactional mode remains unimplemented.
+func TestConfQwpIngressRejectsTransactionOn(t *testing.T) {
+	for _, schema := range []string{"ws", "wss", "qwpws", "qwpwss"} {
+		t.Run(schema, func(t *testing.T) {
+			_, err := confFromStr(schema + "::addr=localhost:9000;transaction=on;")
+			if err == nil {
+				t.Fatal("transaction=on must be rejected until transactional ingestion is implemented")
+			}
+			if !strings.Contains(err.Error(), "not yet supported") {
+				t.Errorf("error %q does not explain that transactional ingestion is unsupported", err)
 			}
 		})
 	}

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -747,10 +747,9 @@ func TestConfQwpRejectsTokenXY(t *testing.T) {
 }
 
 // TestConfUserPassAliases pins user / pass as the deprecated aliases of
-// username / password (Sender.java). The ingress parser interprets them
-// as credentials; the egress parser silently ignores them (matching
-// QwpQueryClient.fromConfig, which interprets only username / password),
-// so a connect string carrying the aliases loads on both sides.
+// username / password (Sender.java). Both QWP directions interpret them
+// as Basic Auth credentials so a shared connect string behaves the same
+// for ingestion and queries.
 func TestConfUserPassAliases(t *testing.T) {
 	conf := "ws::addr=localhost:9000;user=alice;pass=secret;"
 
@@ -765,8 +764,60 @@ func TestConfUserPassAliases(t *testing.T) {
 		t.Errorf("httpPass=%q, want %q", c.httpPass, "secret")
 	}
 
-	if _, err := parseQwpQueryConf(conf); err != nil {
-		t.Errorf("egress rejected user/pass aliases: %v", err)
+	q, err := parseQwpQueryConf(conf)
+	if err != nil {
+		t.Fatalf("egress rejected user/pass aliases: %v", err)
+	}
+	if q.httpUser != "alice" {
+		t.Errorf("egress httpUser=%q, want %q", q.httpUser, "alice")
+	}
+	if q.httpPass != "secret" {
+		t.Errorf("egress httpPass=%q, want %q", q.httpPass, "secret")
+	}
+}
+
+// TestConfAuthAliasesAreCanonicalizedLastWriteWins ensures conflicting
+// deprecated aliases cannot make authentication depend on Go's
+// randomized map iteration order. Both spellings canonicalize to the
+// same key as the string is parsed, so the last value wins like Java's
+// ConfigView.
+func TestConfAuthAliasesAreCanonicalizedLastWriteWins(t *testing.T) {
+	configs := []struct {
+		conf     string
+		wantUser string
+		wantPass string
+	}{
+		{
+			conf:     "ws::addr=localhost:9000;user=alias-user;pass=alias-pass;username=canonical-user;password=canonical-pass;",
+			wantUser: "canonical-user",
+			wantPass: "canonical-pass",
+		},
+		{
+			conf:     "ws::addr=localhost:9000;username=canonical-user;password=canonical-pass;user=alias-user;pass=alias-pass;",
+			wantUser: "alias-user",
+			wantPass: "alias-pass",
+		},
+	}
+	for _, tc := range configs {
+		for i := 0; i < 2000; i++ {
+			ingress, err := confFromStr(tc.conf)
+			if err != nil {
+				t.Fatalf("ingress parse: %v", err)
+			}
+			if ingress.httpUser != tc.wantUser || ingress.httpPass != tc.wantPass {
+				t.Fatalf("ingress iteration %d selected credentials %q/%q, want %s/%s",
+					i, ingress.httpUser, ingress.httpPass, tc.wantUser, tc.wantPass)
+			}
+
+			egress, err := parseQwpQueryConf(tc.conf)
+			if err != nil {
+				t.Fatalf("egress parse: %v", err)
+			}
+			if egress.httpUser != tc.wantUser || egress.httpPass != tc.wantPass {
+				t.Fatalf("egress iteration %d selected credentials %q/%q, want %s/%s",
+					i, egress.httpUser, egress.httpPass, tc.wantUser, tc.wantPass)
+			}
+		}
 	}
 }
 

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -426,6 +426,55 @@ func TestConfSharedConnectString(t *testing.T) {
 	}
 }
 
+// TestConfQwpAcceptsConnectTimeout pins connect_timeout as a shared
+// QWP key. It bounds the TCP connect phase in milliseconds in both the
+// ingress sender and query client, matching the Java QWP clients.
+func TestConfQwpAcceptsConnectTimeout(t *testing.T) {
+	for _, schema := range []string{"ws", "wss", "qwpws", "qwpwss"} {
+		conf := schema + "::addr=localhost:9000;connect_timeout=2500;"
+		t.Run("ingress/"+schema, func(t *testing.T) {
+			cfg, err := confFromStr(conf)
+			if err != nil {
+				t.Fatalf("QWP ingress rejected connect_timeout: %v", err)
+			}
+			if cfg.connectTimeoutMs != 2500 {
+				t.Errorf("ingress connectTimeoutMs=%d, want 2500", cfg.connectTimeoutMs)
+			}
+		})
+		t.Run("egress/"+schema, func(t *testing.T) {
+			cfg, err := parseQwpQueryConf(conf)
+			if err != nil {
+				t.Fatalf("QWP egress rejected connect_timeout: %v", err)
+			}
+			if cfg.connectTimeoutMs != 2500 {
+				t.Errorf("egress connectTimeoutMs=%d, want 2500", cfg.connectTimeoutMs)
+			}
+		})
+	}
+}
+
+func TestConfQwpRejectsInvalidConnectTimeout(t *testing.T) {
+	for _, value := range []string{
+		"0",
+		"-1",
+		"not-an-int",
+		"9223372036855", // overflows time.Duration when converted from milliseconds
+		"9223372036854775808",
+	} {
+		conf := "ws::addr=localhost:9000;connect_timeout=" + value + ";"
+		t.Run("ingress/"+value, func(t *testing.T) {
+			if _, err := confFromStr(conf); err == nil {
+				t.Fatalf("QWP ingress accepted connect_timeout=%s", value)
+			}
+		})
+		t.Run("egress/"+value, func(t *testing.T) {
+			if _, err := parseQwpQueryConf(conf); err == nil {
+				t.Fatalf("QWP egress accepted connect_timeout=%s", value)
+			}
+		})
+	}
+}
+
 // TestConfQwpRejectsRetryTimeout pins the fix for the silent-drop
 // audit finding: retry_timeout is HTTP-only (legacy ILP doc) and is
 // not listed in connect-string.md, and Sender.java:3412 rejects it

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -366,6 +366,7 @@ func TestConfEgressSilentlyAcceptsIngressKeys(t *testing.T) {
 		"auto_flush_interval=100",
 		"auto_flush_rows=1000",
 		"close_flush_timeout_millis=5000",
+		"connection_listener_inbox_capacity=64",
 		"drain_orphans=off",
 		"durable_ack_keepalive_interval_millis=200",
 		"error_inbox_capacity=256",
@@ -390,6 +391,7 @@ func TestConfEgressSilentlyAcceptsIngressKeys(t *testing.T) {
 		"sf_durability=memory",
 		"sf_max_bytes=4m",
 		"sf_max_total_bytes=10g",
+		"transaction=on",
 	}
 	for _, kv := range kvs {
 		t.Run(kv, func(t *testing.T) {
@@ -604,6 +606,156 @@ func TestWithCloseTimeoutSubMillisecondIsNoOverride(t *testing.T) {
 	if !c.closeFlushTimeoutSet || c.closeFlushTimeoutMillis != 1 {
 		t.Errorf("WithCloseTimeout(1ms): set=%v millis=%d; want set=true millis=1",
 			c.closeFlushTimeoutSet, c.closeFlushTimeoutMillis)
+	}
+}
+
+// TestConfQwpIngressAcceptsExtraIngressKeys pins that the ingress-only
+// QWP keys the Java client (Sender.java) accepts but the doc Key index
+// omits — transaction, connection_listener_inbox_capacity — parse on the
+// QWP ingress sender. This client implements neither feature, so they are
+// validated no-ops; accepting them is what lets a connect string shared
+// with a transaction-aware client still load here. The UDP-only keys
+// max_datagram_size / multicast_ttl are excluded: QWP rejects them (see
+// TestConfQwpRejectsUdpKeys).
+func TestConfQwpIngressAcceptsExtraIngressKeys(t *testing.T) {
+	kvs := []string{
+		"transaction=on",
+		"transaction=off",
+		"connection_listener_inbox_capacity=64",
+	}
+	for _, kv := range kvs {
+		t.Run(kv, func(t *testing.T) {
+			conf := "ws::addr=localhost:9000;" + kv + ";"
+			if _, err := confFromStr(conf); err != nil {
+				t.Errorf("QWP ingress rejected %q: %v", kv, err)
+			}
+		})
+	}
+}
+
+// TestConfQwpRejectsUdpKeys pins that the UDP-only ingress keys
+// max_datagram_size / multicast_ttl are rejected on the QWP path by
+// BOTH clients. The unified config API drives the QWP WebSocket
+// transport, where UDP datagram knobs never apply, so a ws:: / wss::
+// connect string carrying them is surfaced as malformed -- mirroring the
+// protocol_version / retry_timeout rejects. The error names the offending
+// key and explains the UDP-only scope.
+func TestConfQwpRejectsUdpKeys(t *testing.T) {
+	for _, k := range []string{"max_datagram_size", "multicast_ttl"} {
+		kv := k + "=1400"
+		for _, schema := range []string{"ws", "wss", "qwpws", "qwpwss"} {
+			t.Run("ingress/"+schema+"/"+k, func(t *testing.T) {
+				_, err := confFromStr(schema + "::addr=localhost:9000;" + kv + ";")
+				if err == nil {
+					t.Fatalf("QWP ingress must reject %q on %s::", kv, schema)
+				}
+				msg := err.Error()
+				if !strings.Contains(msg, k) {
+					t.Errorf("error %q does not name %s", msg, k)
+				}
+				if !strings.Contains(msg, "UDP") {
+					t.Errorf("error %q does not explain the UDP-only scope", msg)
+				}
+			})
+		}
+		t.Run("egress/"+k, func(t *testing.T) {
+			if _, err := parseQwpQueryConf("ws::addr=localhost:9000;" + kv + ";"); err == nil {
+				t.Fatalf("QWP egress must reject %q", kv)
+			}
+		})
+	}
+}
+
+// TestConfUdpKeysAcceptedOnHttpAndTcp pins that the rejection is
+// QWP-scoped: on the legacy ILP transports this client has no UDP path
+// either, so max_datagram_size / multicast_ttl stay inert validated
+// no-ops -- a valid value parses, and a malformed one still errors via
+// the shape check.
+func TestConfUdpKeysAcceptedOnHttpAndTcp(t *testing.T) {
+	for _, schema := range []string{"http", "https", "tcp", "tcps"} {
+		for _, kv := range []string{"max_datagram_size=1400", "multicast_ttl=1"} {
+			t.Run("accept/"+schema+"/"+kv, func(t *testing.T) {
+				if _, err := confFromStr(schema + "::addr=localhost:9000;" + kv + ";"); err != nil {
+					t.Errorf("%s:: must accept %q: %v", schema, kv, err)
+				}
+			})
+		}
+		t.Run("rejectMalformed/"+schema, func(t *testing.T) {
+			if _, err := confFromStr(schema + "::addr=localhost:9000;max_datagram_size=abc;"); err == nil {
+				t.Errorf("%s:: must reject a non-int max_datagram_size", schema)
+			}
+		})
+	}
+}
+
+// TestConfTransactionRejectedOnHttpAndTcp pins the Java gating
+// (Sender.java: "transaction is only supported for WebSocket
+// transport"). transaction and connection_listener_inbox_capacity are
+// WebSocket-only ingress keys; the legacy ILP transports never carry
+// them, so the parser rejects them there.
+func TestConfTransactionRejectedOnHttpAndTcp(t *testing.T) {
+	for _, kv := range []string{"transaction=on", "connection_listener_inbox_capacity=64"} {
+		for _, schema := range []string{"http", "tcp"} {
+			t.Run(schema+"/"+kv, func(t *testing.T) {
+				_, err := confFromStr(schema + "::addr=localhost:9000;" + kv + ";")
+				if err == nil {
+					t.Fatalf("%s:: must reject %q", schema, kv)
+				}
+				if !strings.Contains(err.Error(), "only supported for QWP") {
+					t.Errorf("error %q does not explain the QWP-only gating", err.Error())
+				}
+			})
+		}
+	}
+}
+
+// TestConfQwpRejectsTokenXY pins that the TCP ILP public-key auth keys
+// token_x / token_y are rejected on the QWP path by BOTH clients. They
+// are absent from the QWP connect-string vocabulary; the egress parser
+// already rejected them, and the ingress parser now matches so the two
+// QWP clients treat a shared string symmetrically. The legacy ILP
+// transports still accept (and ignore) them — covered by the TCP case
+// in conf_test.go.
+func TestConfQwpRejectsTokenXY(t *testing.T) {
+	for _, kv := range []string{"token_x=xyz", "token_y=xyz"} {
+		t.Run("ingress/"+kv, func(t *testing.T) {
+			if _, err := confFromStr("ws::addr=localhost:9000;" + kv + ";"); err == nil {
+				t.Fatalf("QWP ingress must reject %q", kv)
+			}
+		})
+		t.Run("egress/"+kv, func(t *testing.T) {
+			if _, err := parseQwpQueryConf("ws::addr=localhost:9000;" + kv + ";"); err == nil {
+				t.Fatalf("QWP egress must reject %q", kv)
+			}
+		})
+	}
+	// The same keys remain accepted (and ignored) on the legacy ILP tcp:: schema.
+	if _, err := confFromStr("tcp::addr=localhost:9000;username=u;token=t;token_x=xyz;token_y=xyz;"); err != nil {
+		t.Errorf("tcp:: must still accept token_x/token_y: %v", err)
+	}
+}
+
+// TestConfUserPassAliases pins user / pass as the deprecated aliases of
+// username / password (Sender.java). The ingress parser interprets them
+// as credentials; the egress parser silently ignores them (matching
+// QwpQueryClient.fromConfig, which interprets only username / password),
+// so a connect string carrying the aliases loads on both sides.
+func TestConfUserPassAliases(t *testing.T) {
+	conf := "ws::addr=localhost:9000;user=alice;pass=secret;"
+
+	c, err := confFromStr(conf)
+	if err != nil {
+		t.Fatalf("ingress rejected user/pass aliases: %v", err)
+	}
+	if c.httpUser != "alice" {
+		t.Errorf("httpUser=%q, want %q", c.httpUser, "alice")
+	}
+	if c.httpPass != "secret" {
+		t.Errorf("httpPass=%q, want %q", c.httpPass, "secret")
+	}
+
+	if _, err := parseQwpQueryConf(conf); err != nil {
+		t.Errorf("egress rejected user/pass aliases: %v", err)
 	}
 }
 

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -466,6 +466,68 @@ func TestConfQwpRejectsWithRetryTimeoutOption(t *testing.T) {
 	}
 }
 
+// TestConfQwpIngressRejectsNonQwpKeys pins that the legacy ILP HTTP keys
+// absent from the QWP connect-string vocabulary (connect-string.md Key
+// index) are rejected by the QWP ingress sender. retry_timeout has its own
+// dedicated test above (with the migration-hint assertion); this covers
+// request_timeout, request_min_throughput, and a concrete protocol_version.
+func TestConfQwpIngressRejectsNonQwpKeys(t *testing.T) {
+	keys := []string{
+		"request_timeout=10000",
+		"request_min_throughput=102400",
+		"protocol_version=2",
+		"protocol_version=auto",
+	}
+	for _, kv := range keys {
+		t.Run(kv, func(t *testing.T) {
+			_, err := LineSenderFromConf(context.Background(),
+				"ws::addr=localhost:9000;"+kv+";")
+			if err == nil {
+				t.Fatalf("expected error: %q must not be accepted on QWP ingress", kv)
+			}
+		})
+	}
+}
+
+// TestConfQwpIngressAcceptsNonQwpKeysOnHttp proves the rejection is
+// schema-scoped: the same keys remain valid on the legacy ILP http:: schema.
+func TestConfQwpIngressAcceptsNonQwpKeysOnHttp(t *testing.T) {
+	keys := []string{
+		"request_timeout=10000",
+		"request_min_throughput=102400",
+		"retry_timeout=10000",
+		"protocol_version=2",
+		"protocol_version=auto",
+	}
+	for _, kv := range keys {
+		t.Run(kv, func(t *testing.T) {
+			if _, err := confFromStr("http::addr=localhost:9000;" + kv + ";"); err != nil {
+				t.Fatalf("http:: must accept %q: %v", kv, err)
+			}
+		})
+	}
+}
+
+// TestConfQwpEgressRejectsNonQwpKeys is the egress side: the QwpQueryClient
+// parser rejects the same legacy ILP keys. Unlike the ingress, the egress has
+// no protocol_version=auto pass-through, so even that value is rejected.
+func TestConfQwpEgressRejectsNonQwpKeys(t *testing.T) {
+	keys := []string{
+		"request_timeout=10000",
+		"request_min_throughput=102400",
+		"retry_timeout=10000",
+		"protocol_version=2",
+		"protocol_version=auto",
+	}
+	for _, kv := range keys {
+		t.Run(kv, func(t *testing.T) {
+			if _, err := parseQwpQueryConf("ws::addr=localhost:9000;" + kv + ";"); err == nil {
+				t.Fatalf("expected error: %q must not be accepted on QWP egress", kv)
+			}
+		})
+	}
+}
+
 // TestConfRejectsCloseTimeoutWithMigrationHint pins the removal of
 // the Go-only `close_timeout` key. Java never accepted it (only
 // close_flush_timeout_millis, Sender.java §3071), and the cursor

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -156,7 +156,7 @@ func TestConfSizeSuffixAppliedToKeys(t *testing.T) {
 		"max_buf_size=10m;" +
 		"auto_flush_bytes=4m;" +
 		"sf_dir=/tmp/sf;sender_id=t;" +
-		"sf_max_bytes=4m;" +
+		"sf_max_segment_bytes=4m;" +
 		"sf_max_total_bytes=1g;")
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -170,8 +170,8 @@ func TestConfSizeSuffixAppliedToKeys(t *testing.T) {
 	if c.autoFlushBytes != 4<<20 {
 		t.Errorf("autoFlushBytes=%d, want %d", c.autoFlushBytes, 4<<20)
 	}
-	if c.sfMaxBytes != int64(4<<20) {
-		t.Errorf("sfMaxBytes=%d, want %d", c.sfMaxBytes, 4<<20)
+	if c.sfMaxSegmentBytes != int64(4<<20) {
+		t.Errorf("sfMaxSegmentBytes=%d, want %d", c.sfMaxSegmentBytes, 4<<20)
 	}
 	if c.sfMaxTotalBytes != int64(1<<30) {
 		t.Errorf("sfMaxTotalBytes=%d, want %d", c.sfMaxTotalBytes, 1<<30)
@@ -389,7 +389,7 @@ func TestConfEgressSilentlyAcceptsIngressKeys(t *testing.T) {
 		"sf_append_deadline_millis=30000",
 		"sf_dir=/tmp/sf",
 		"sf_durability=memory",
-		"sf_max_bytes=4m",
+		"sf_max_segment_bytes=4m",
 		"sf_max_total_bytes=10g",
 		"transaction=on",
 	}

--- a/conf_audit_test.go
+++ b/conf_audit_test.go
@@ -664,6 +664,7 @@ func TestWithCloseTimeoutSubMillisecondIsNoOverride(t *testing.T) {
 func TestConfQwpIngressAcceptsExtraIngressKeys(t *testing.T) {
 	kvs := []string{
 		"transaction=off",
+		"connection_listener_inbox_capacity=1",
 		"connection_listener_inbox_capacity=64",
 	}
 	for _, kv := range kvs {
@@ -765,6 +766,19 @@ func TestConfTransactionRejectedOnHttpAndTcp(t *testing.T) {
 					t.Errorf("error %q does not explain the QWP-only gating", err.Error())
 				}
 			})
+		}
+	}
+}
+
+func TestConfQwpIngressRejectsInvalidConnectionListenerInboxCapacity(t *testing.T) {
+	for _, value := range []string{"0", "-1"} {
+		_, err := confFromStr(
+			"ws::addr=localhost:9000;connection_listener_inbox_capacity=" + value + ";")
+		if err == nil {
+			t.Fatalf("connection_listener_inbox_capacity=%s must be rejected", value)
+		}
+		if !strings.Contains(err.Error(), "must be >= 1") {
+			t.Errorf("error %q does not report the >= 1 requirement", err)
 		}
 	}
 }

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -278,15 +278,6 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 				}
 				senderConf.protocolVersion = pVersion
 			}
-		case "in_flight_window":
-			if senderConf.senderType != qwpSenderType {
-				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
-			}
-			parsedVal, err := strconv.Atoi(v)
-			if err != nil {
-				return nil, NewInvalidConfigStrError("invalid %s value, %q is not a valid int", k, v)
-			}
-			senderConf.inFlightWindow = parsedVal
 		case "close_timeout":
 			// Java client never accepted close_timeout — only
 			// close_flush_timeout_millis (Sender.java §3071). The

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -271,6 +271,15 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		case "tls_roots_password":
 			return nil, NewInvalidConfigStrError("tls_roots_password is not available in the go client")
 		case "protocol_version":
+			if senderConf.senderType == qwpSenderType {
+				// protocol_version is not part of the QWP connect-string
+				// vocabulary -- the version is negotiated at the WebSocket
+				// upgrade. Reject any value (including "auto") so a ws:: string
+				// carrying it is surfaced as malformed, matching the egress
+				// QwpQueryClient and the other language clients.
+				return nil, NewInvalidConfigStrError(
+					"protocol_version is not supported for QWP; the protocol version is negotiated during the WebSocket upgrade")
+			}
 			if v != "auto" {
 				version, err := strconv.Atoi(v)
 				if err != nil {

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -578,16 +578,20 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			}
 		case "transaction":
 			// Transactional ingestion is a WebSocket-only ingress feature
-			// (Sender.java). This client does not implement it; the key is
-			// accepted on QWP as a validated no-op so a connect string
-			// shared with a transaction-aware client still parses. Rejected
-			// on the legacy ILP transports, which never carry it.
+			// (Sender.java). This client does not implement it, so an
+			// explicit opt-in must fail instead of silently producing
+			// ordinary writes. Rejected on the legacy ILP transports,
+			// which never carry it.
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
 			}
 			switch v {
-			case "on", "off":
-				// Accepted; this client has no transactional mode to toggle.
+			case "off":
+				// The default; this client has no transactional mode to
+				// disable.
+			case "on":
+				return nil, NewInvalidConfigStrError(
+					"transaction=on is not yet supported: transactional ingestion is not implemented in this client (use transaction=off)")
 			default:
 				return nil, NewInvalidConfigStrError(
 					"invalid %s value, %q is not 'on' or 'off'", k, v)

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -104,7 +104,7 @@ var ingressOnlyKeys = map[string]bool{
 	"sf_append_deadline_millis":             true,
 	"sf_dir":                                true,
 	"sf_durability":                         true,
-	"sf_max_segment_bytes":                          true,
+	"sf_max_segment_bytes":                  true,
 	"sf_max_total_bytes":                    true,
 	"transaction":                           true,
 }

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -68,10 +68,9 @@ var egressOnlyKeys = map[string]bool{
 // shared ws:: / wss:: connect string works in both directions. The set
 // is the connect-string.md §Key index ingress keys plus the
 // ingress-only keys the Java client (Sender.java) accepts that the doc
-// Key index omits: transaction, connection_listener_inbox_capacity, and
-// the user / pass auth aliases. The auth aliases are interpreted by the
-// ingress parser (username / password equivalents) but ignored on
-// egress, matching QwpQueryClient.fromConfig. The UDP-only keys
+// Key index omits: transaction and connection_listener_inbox_capacity.
+// The user / pass auth aliases are shared keys, canonicalized to
+// username / password by parseConfigStr. The UDP-only keys
 // max_datagram_size and multicast_ttl are deliberately absent: QWP is
 // the WebSocket transport, so both QWP parsers reject them. Same SSOT as
 // egressOnlyKeys.
@@ -96,7 +95,6 @@ var ingressOnlyKeys = map[string]bool{
 	"on_security_error":                     true,
 	"on_server_error":                       true,
 	"on_write_error":                        true,
-	"pass":                                  true,
 	"reconnect_initial_backoff_millis":      true,
 	"reconnect_max_backoff_millis":          true,
 	"reconnect_max_duration_millis":         true,
@@ -108,7 +106,6 @@ var ingressOnlyKeys = map[string]bool{
 	"sf_max_segment_bytes":                          true,
 	"sf_max_total_bytes":                    true,
 	"transaction":                           true,
-	"user":                                  true,
 }
 
 func confFromStr(conf string) (*lineSenderConfig, error) {
@@ -783,6 +780,7 @@ func parseConfigStr(conf string) (configData, error) {
 		result = configData{
 			KeyValuePairs: map[string]string{},
 		}
+		seenKeys = map[string]bool{}
 
 		nextRune   rune
 		isEscaping bool
@@ -834,19 +832,23 @@ func parseConfigStr(conf string) (configData, error) {
 				return result, NewInvalidConfigStrError("empty value for key %q", key)
 			}
 
-			// Reject duplicate keys (case-sensitive) for parity with Rust and
-			// the per-field checks in Java; otherwise dups would silently LWW.
+			// Reject duplicate raw keys (case-sensitive) for parity with Rust
+			// and the per-field checks in Java. Deprecated aliases are
+			// canonicalized after this raw-duplicate check, so an
+			// alias/canonical pair is allowed and resolves last-write-wins.
 			// `addr` is the documented exception: the failover spec (§1)
 			// allows `addr=h1;addr=h2` as an alternative spelling of
 			// `addr=h1,h2`. Both forms accumulate into a single
 			// comma-joined value so downstream parsers see one shape.
-			keyStr := key.String()
-			if existing, exists := result.KeyValuePairs[keyStr]; exists {
-				if keyStr == "addr" {
-					result.KeyValuePairs[keyStr] = existing + "," + value.String()
-				} else {
-					return result, NewInvalidConfigStrError("duplicate key %q", keyStr)
-				}
+			rawKey := key.String()
+			if seenKeys[rawKey] && rawKey != "addr" {
+				return result, NewInvalidConfigStrError("duplicate key %q", rawKey)
+			}
+			seenKeys[rawKey] = true
+
+			keyStr := canonicalConfigKey(rawKey)
+			if existing, exists := result.KeyValuePairs[keyStr]; exists && keyStr == "addr" {
+				result.KeyValuePairs[keyStr] = existing + "," + value.String()
 			} else {
 				result.KeyValuePairs[keyStr] = value.String()
 			}
@@ -874,4 +876,15 @@ func parseConfigStr(conf string) (configData, error) {
 	}
 
 	return result, nil
+}
+
+func canonicalConfigKey(key string) string {
+	switch key {
+	case "user":
+		return "username"
+	case "pass":
+		return "password"
+	default:
+		return key
+	}
 }

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -105,7 +105,7 @@ var ingressOnlyKeys = map[string]bool{
 	"sf_append_deadline_millis":             true,
 	"sf_dir":                                true,
 	"sf_durability":                         true,
-	"sf_max_bytes":                          true,
+	"sf_max_segment_bytes":                          true,
 	"sf_max_total_bytes":                    true,
 	"transaction":                           true,
 	"user":                                  true,
@@ -332,19 +332,19 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 				return nil, err
 			}
 			senderConf.senderId = v
-		case "sf_max_bytes":
+		case "sf_max_segment_bytes":
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
 			}
 			// 0 is the "use the default segment size" sentinel, resolved
 			// at construction (qwpSfDefaultMaxBytes), matching the
-			// WithSfMaxBytes option path. parseSizeBytes already rejects
+			// WithSfMaxSegmentBytes option path. parseSizeBytes already rejects
 			// negative and non-numeric input.
 			parsedVal, err := parseSizeBytes(v)
 			if err != nil {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q must be a non-negative size", k, v)
 			}
-			senderConf.sfMaxBytes = parsedVal
+			senderConf.sfMaxSegmentBytes = parsedVal
 		case "sf_max_total_bytes":
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -48,6 +48,7 @@ type configData struct {
 // only.
 var egressOnlyKeys = map[string]bool{
 	"buffer_pool_size":            true,
+	"client_id":                   true,
 	"compression":                 true,
 	"compression_level":           true,
 	"failover":                    true,
@@ -57,6 +58,9 @@ var egressOnlyKeys = map[string]bool{
 	"failover_max_duration_ms":    true,
 	"initial_credit":              true,
 	"max_batch_rows":              true,
+	"path":                        true,
+	"replay_exec":                 true,
+	"server_info_timeout_ms":      true,
 }
 
 // ingressOnlyKeys lists connect-string keys defined by the spec for

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -610,9 +610,14 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
 			}
-			if _, err := strconv.Atoi(v); err != nil {
+			parsedVal, err := strconv.Atoi(v)
+			if err != nil {
 				return nil, NewInvalidConfigStrError(
 					"invalid %s value, %q is not a valid int", k, v)
+			}
+			if parsedVal < 1 {
+				return nil, NewInvalidConfigStrError(
+					"invalid %s value, %d: must be >= 1", k, parsedVal)
 			}
 		case "max_datagram_size", "multicast_ttl":
 			// UDP-only ingress keys (Sender.java accepts them on every

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -26,6 +26,7 @@ package questdb
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -380,6 +381,15 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 				return nil, NewInvalidConfigStrError("invalid %s value, %q must be a positive int (milliseconds)", k, v)
 			}
 			senderConf.authTimeoutMs = parsedVal
+		case "connect_timeout":
+			if senderConf.senderType != qwpSenderType {
+				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
+			}
+			parsedVal, err := parseConnectTimeoutMillis(v)
+			if err != nil {
+				return nil, err
+			}
+			senderConf.connectTimeoutMs = parsedVal
 		case "zone":
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
@@ -746,6 +756,21 @@ func parseSizeBytes(v string) (int64, error) {
 		return 0, fmt.Errorf("size %q overflows int64", v)
 	}
 	return n * mult, nil
+}
+
+func parseConnectTimeoutMillis(value string) (int, error) {
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, NewInvalidConfigStrError(
+			"invalid connect_timeout value, %q must be a positive int (milliseconds)", value)
+	}
+	const maxDurationMillis = math.MaxInt64 / int64(time.Millisecond)
+	if int64(parsed) > maxDurationMillis {
+		return 0, NewInvalidConfigStrError(
+			"invalid connect_timeout value, %q exceeds the maximum of %d milliseconds",
+			value, maxDurationMillis)
+	}
+	return parsed, nil
 }
 
 // validateSenderId enforces the same character set the Java client

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -63,17 +63,25 @@ var egressOnlyKeys = map[string]bool{
 	"server_info_timeout_ms":      true,
 }
 
-// ingressOnlyKeys lists connect-string keys defined by the spec for
-// the ingress LineSender only. The egress QwpQueryClient silently
-// accepts them so a shared connect string works in both directions.
-// Same SSOT as egressOnlyKeys; the lists are kept in sync with
-// connect-string.md §Key index.
+// ingressOnlyKeys lists connect-string keys the ingress LineSender
+// interprets and the egress QwpQueryClient silently accepts, so a
+// shared ws:: / wss:: connect string works in both directions. The set
+// is the connect-string.md §Key index ingress keys plus the
+// ingress-only keys the Java client (Sender.java) accepts that the doc
+// Key index omits: transaction, connection_listener_inbox_capacity, and
+// the user / pass auth aliases. The auth aliases are interpreted by the
+// ingress parser (username / password equivalents) but ignored on
+// egress, matching QwpQueryClient.fromConfig. The UDP-only keys
+// max_datagram_size and multicast_ttl are deliberately absent: QWP is
+// the WebSocket transport, so both QWP parsers reject them. Same SSOT as
+// egressOnlyKeys.
 var ingressOnlyKeys = map[string]bool{
 	"auto_flush":                            true,
 	"auto_flush_bytes":                      true,
 	"auto_flush_interval":                   true,
 	"auto_flush_rows":                       true,
 	"close_flush_timeout_millis":            true,
+	"connection_listener_inbox_capacity":    true,
 	"drain_orphans":                         true,
 	"durable_ack_keepalive_interval_millis": true,
 	"error_inbox_capacity":                  true,
@@ -88,6 +96,7 @@ var ingressOnlyKeys = map[string]bool{
 	"on_security_error":                     true,
 	"on_server_error":                       true,
 	"on_write_error":                        true,
+	"pass":                                  true,
 	"reconnect_initial_backoff_millis":      true,
 	"reconnect_max_backoff_millis":          true,
 	"reconnect_max_duration_millis":         true,
@@ -98,6 +107,8 @@ var ingressOnlyKeys = map[string]bool{
 	"sf_durability":                         true,
 	"sf_max_bytes":                          true,
 	"sf_max_total_bytes":                    true,
+	"transaction":                           true,
+	"user":                                  true,
 }
 
 func confFromStr(conf string) (*lineSenderConfig, error) {
@@ -156,7 +167,8 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		switch k {
 		case "addr":
 			senderConf.address = v
-		case "username":
+		case "username", "user":
+			// user is the deprecated alias of username (Sender.java).
 			switch senderConf.senderType {
 			case httpSenderType, qwpSenderType:
 				senderConf.httpUser = v
@@ -165,7 +177,8 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			default:
 				panic("add a case for " + k)
 			}
-		case "password":
+		case "password", "pass":
+			// pass is the deprecated alias of password (Sender.java).
 			if senderConf.senderType != httpSenderType && senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for HTTP and QWP senders", k)
 			}
@@ -179,10 +192,15 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			default:
 				panic("add a case for " + k)
 			}
-		case "token_x":
-		case "token_y":
-			// Some clients require public key.
-			// But since Go sender doesn't need it, we ignore the values.
+		case "token_x", "token_y":
+			// TCP ILP public-key auth components (ECDSA P-256 X/Y). They
+			// are not part of the QWP connect-string vocabulary, so reject
+			// them on QWP for symmetry with the egress QwpQueryClient, which
+			// also rejects them. On the legacy ILP transports this client
+			// does not need the public key, so the values are ignored.
+			if senderConf.senderType == qwpSenderType {
+				return nil, NewInvalidConfigStrError("unsupported option %q", k)
+			}
 			continue
 		case "auto_flush":
 			// Resolved in the deterministic pre-pass above so map
@@ -557,6 +575,50 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			if _, err := strconv.Atoi(v); err != nil {
 				return nil, NewInvalidConfigStrError(
 					"invalid %s value, %q is not a valid int (milliseconds)", k, v)
+			}
+		case "transaction":
+			// Transactional ingestion is a WebSocket-only ingress feature
+			// (Sender.java). This client does not implement it; the key is
+			// accepted on QWP as a validated no-op so a connect string
+			// shared with a transaction-aware client still parses. Rejected
+			// on the legacy ILP transports, which never carry it.
+			if senderConf.senderType != qwpSenderType {
+				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
+			}
+			switch v {
+			case "on", "off":
+				// Accepted; this client has no transactional mode to toggle.
+			default:
+				return nil, NewInvalidConfigStrError(
+					"invalid %s value, %q is not 'on' or 'off'", k, v)
+			}
+		case "connection_listener_inbox_capacity":
+			// WebSocket-only ingress key (Sender.java). This client exposes
+			// no connection-listener inbox; accepted on QWP as a validated
+			// no-op for connect-string portability, rejected on legacy ILP.
+			if senderConf.senderType != qwpSenderType {
+				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
+			}
+			if _, err := strconv.Atoi(v); err != nil {
+				return nil, NewInvalidConfigStrError(
+					"invalid %s value, %q is not a valid int", k, v)
+			}
+		case "max_datagram_size", "multicast_ttl":
+			// UDP-only ingress keys (Sender.java accepts them on every
+			// transport). QWP is the WebSocket transport, where these keys
+			// never apply, so reject them on a ws:: / wss:: connect string,
+			// mirroring the egress QwpQueryClient and the protocol_version /
+			// retry_timeout rejects. On the legacy ILP transports this client
+			// has no UDP path either, so the key is inert there; the value is
+			// shape-validated so a typo still errors, and the key is accepted
+			// so a connect string shared across those transports parses.
+			if senderConf.senderType == qwpSenderType {
+				return nil, NewInvalidConfigStrError(
+					"%s is not supported for QWP; it applies to the UDP transport only", k)
+			}
+			if _, err := strconv.Atoi(v); err != nil {
+				return nil, NewInvalidConfigStrError(
+					"invalid %s value, %q is not a valid int", k, v)
 			}
 		default:
 			if senderConf.senderType == qwpSenderType && egressOnlyKeys[k] {

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -288,18 +288,6 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			// going through the generic "unsupported option" path.
 			return nil, NewInvalidConfigStrError(
 				"close_timeout is no longer supported; use close_flush_timeout_millis instead")
-		case "gorilla":
-			if senderConf.senderType != qwpSenderType {
-				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)
-			}
-			switch v {
-			case "on":
-				senderConf.gorillaDisabled = false
-			case "off":
-				senderConf.gorillaDisabled = true
-			default:
-				return nil, NewInvalidConfigStrError("invalid gorilla value, %q is not 'on' or 'off'", v)
-			}
 		case "sf_dir":
 			if senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for QWP senders", k)

--- a/conf_parse.go
+++ b/conf_parse.go
@@ -165,8 +165,9 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 		switch k {
 		case "addr":
 			senderConf.address = v
-		case "username", "user":
-			// user is the deprecated alias of username (Sender.java).
+		case "username":
+			// The `user` alias is canonicalized to `username` by
+			// parseConfigStr, so this case handles both spellings.
 			switch senderConf.senderType {
 			case httpSenderType, qwpSenderType:
 				senderConf.httpUser = v
@@ -175,8 +176,9 @@ func confFromStr(conf string) (*lineSenderConfig, error) {
 			default:
 				panic("add a case for " + k)
 			}
-		case "password", "pass":
-			// pass is the deprecated alias of password (Sender.java).
+		case "password":
+			// The `pass` alias is canonicalized to `password` by
+			// parseConfigStr, so this case handles both spellings.
 			if senderConf.senderType != httpSenderType && senderConf.senderType != qwpSenderType {
 				return nil, NewInvalidConfigStrError("%s is only supported for HTTP and QWP senders", k)
 			}

--- a/conf_test.go
+++ b/conf_test.go
@@ -581,24 +581,6 @@ func TestHappyCasesFromConf(t *testing.T) {
 			},
 		},
 		{
-			name:   "ws with gorilla=off",
-			config: fmt.Sprintf("ws::addr=%s;gorilla=off;", addr),
-			expectedOpts: []qdb.LineSenderOption{
-				qdb.WithQwp(),
-				qdb.WithAddress(addr),
-				qdb.WithGorilla(false),
-			},
-		},
-		{
-			name:   "ws with gorilla=on",
-			config: fmt.Sprintf("ws::addr=%s;gorilla=on;", addr),
-			expectedOpts: []qdb.LineSenderOption{
-				qdb.WithQwp(),
-				qdb.WithAddress(addr),
-				qdb.WithGorilla(true),
-			},
-		},
-		{
 			name:   "ws with auth_timeout_ms",
 			config: fmt.Sprintf("ws::addr=%s;auth_timeout_ms=7000;", addr),
 			expectedOpts: []qdb.LineSenderOption{
@@ -721,11 +703,6 @@ func TestPathologicalCasesFromConf(t *testing.T) {
 			expectedErrMsgContains: "invalid auto_flush_interval",
 		},
 		{
-			name:                   "invalid gorilla value",
-			config:                 "ws::addr=localhost:1111;gorilla=maybe;",
-			expectedErrMsgContains: "not 'on' or 'off'",
-		},
-		{
 			name:                   "in_flight_window on HTTP",
 			config:                 "http::addr=localhost:1111;in_flight_window=4;",
 			expectedErrMsgContains: "unsupported option",
@@ -738,11 +715,6 @@ func TestPathologicalCasesFromConf(t *testing.T) {
 			name:                   "close_timeout rejected with migration hint",
 			config:                 "tcp::addr=localhost:1111;close_timeout=1000;",
 			expectedErrMsgContains: "close_timeout is no longer supported",
-		},
-		{
-			name:                   "gorilla on TCP",
-			config:                 "tcp::addr=localhost:1111;gorilla=off;",
-			expectedErrMsgContains: "gorilla is only supported for QWP senders",
 		},
 		{
 			name:                   "unsupported option",
@@ -976,7 +948,6 @@ func TestQwpOnlyOptionsRejectedOnHttpAndTcp(t *testing.T) {
 		{"initial_connect_retry", qdb.WithInitialConnectRetry(true), "initial_connect_retry"},
 		{"close_flush_timeout", qdb.WithCloseFlushTimeout(5 * time.Second), "close_flush_timeout_millis"},
 		{"close_timeout_alias", qdb.WithCloseTimeout(5 * time.Second), "close_flush_timeout_millis"},
-		{"gorilla", qdb.WithGorilla(false), "gorilla"},
 		{"auth_timeout", qdb.WithAuthTimeout(5 * time.Second), "auth_timeout_ms"},
 		{"zone", qdb.WithZone("eu-west-1a"), "zone"},
 		{"target", qdb.WithTarget(qdb.QwpTargetPrimary), "target"},

--- a/conf_test.go
+++ b/conf_test.go
@@ -590,6 +590,15 @@ func TestHappyCasesFromConf(t *testing.T) {
 			},
 		},
 		{
+			name:   "ws with connect_timeout",
+			config: fmt.Sprintf("ws::addr=%s;connect_timeout=7000;", addr),
+			expectedOpts: []qdb.LineSenderOption{
+				qdb.WithQwp(),
+				qdb.WithAddress(addr),
+				qdb.WithConnectTimeout(7 * time.Second),
+			},
+		},
+		{
 			name:   "ws with target=primary",
 			config: fmt.Sprintf("ws::addr=%s;target=primary;", addr),
 			expectedOpts: []qdb.LineSenderOption{
@@ -949,6 +958,7 @@ func TestQwpOnlyOptionsRejectedOnHttpAndTcp(t *testing.T) {
 		{"close_flush_timeout", qdb.WithCloseFlushTimeout(5 * time.Second), "close_flush_timeout_millis"},
 		{"close_timeout_alias", qdb.WithCloseTimeout(5 * time.Second), "close_flush_timeout_millis"},
 		{"auth_timeout", qdb.WithAuthTimeout(5 * time.Second), "auth_timeout_ms"},
+		{"connect_timeout", qdb.WithConnectTimeout(5 * time.Second), "connect_timeout"},
 		{"zone", qdb.WithZone("eu-west-1a"), "zone"},
 		{"target", qdb.WithTarget(qdb.QwpTargetPrimary), "target"},
 		{"qwp_dump_writer", qdb.WithQwpDumpWriter(io.Discard), "QWP dump writer"},

--- a/conf_test.go
+++ b/conf_test.go
@@ -257,17 +257,6 @@ func TestParserHappyCases(t *testing.T) {
 			},
 		},
 		{
-			name:   "ws with in_flight_window",
-			config: fmt.Sprintf("ws::addr=%s;in_flight_window=4;", addr),
-			expected: qdb.ConfigData{
-				Schema: "ws",
-				KeyValuePairs: map[string]string{
-					"addr":              addr,
-					"in_flight_window": "4",
-				},
-			},
-		},
-		{
 			// failover.md §1: `addr=h1;addr=h2` is an alternative
 			// spelling of `addr=h1,h2`. The parser MUST accumulate
 			// both forms into a single comma-joined value.
@@ -559,15 +548,6 @@ func TestHappyCasesFromConf(t *testing.T) {
 			},
 		},
 		{
-			name:   "ws with in_flight_window",
-			config: fmt.Sprintf("ws::addr=%s;in_flight_window=4;", addr),
-			expectedOpts: []qdb.LineSenderOption{
-				qdb.WithQwp(),
-				qdb.WithAddress(addr),
-				qdb.WithInFlightWindow(4),
-			},
-		},
-		{
 			// retry_timeout is intentionally NOT paired with ws here: the
 			// parser maps it to WithRetryTimeout for any schema, but the
 			// QWP sanitizer rejects it (see TestQwpSanitizeRejectsRetryTimeout),
@@ -748,7 +728,7 @@ func TestPathologicalCasesFromConf(t *testing.T) {
 		{
 			name:                   "in_flight_window on HTTP",
 			config:                 "http::addr=localhost:1111;in_flight_window=4;",
-			expectedErrMsgContains: "in_flight_window is only supported for QWP senders",
+			expectedErrMsgContains: "unsupported option",
 		},
 		{
 			// close_timeout was a Go-only legacy key; the Java client
@@ -997,7 +977,6 @@ func TestQwpOnlyOptionsRejectedOnHttpAndTcp(t *testing.T) {
 		{"close_flush_timeout", qdb.WithCloseFlushTimeout(5 * time.Second), "close_flush_timeout_millis"},
 		{"close_timeout_alias", qdb.WithCloseTimeout(5 * time.Second), "close_flush_timeout_millis"},
 		{"gorilla", qdb.WithGorilla(false), "gorilla"},
-		{"in_flight_window", qdb.WithInFlightWindow(8), "in_flight_window"},
 		{"auth_timeout", qdb.WithAuthTimeout(5 * time.Second), "auth_timeout_ms"},
 		{"zone", qdb.WithZone("eu-west-1a"), "zone"},
 		{"target", qdb.WithTarget(qdb.QwpTargetPrimary), "target"},

--- a/conf_test.go
+++ b/conf_test.go
@@ -937,7 +937,7 @@ func TestQwpOnlyOptionsRejectedOnHttpAndTcp(t *testing.T) {
 	}{
 		{"sf_dir", qdb.WithSfDir("/tmp/sf"), "sf_dir"},
 		{"sender_id", qdb.WithSenderId("ingest-1"), "sender_id"},
-		{"sf_max_bytes", qdb.WithSfMaxBytes(1 << 20), "sf_max_bytes"},
+		{"sf_max_segment_bytes", qdb.WithSfMaxSegmentBytes(1 << 20), "sf_max_segment_bytes"},
 		{"sf_max_total_bytes", qdb.WithSfMaxTotalBytes(1 << 30), "sf_max_total_bytes"},
 		{"sf_durability", qdb.WithSfDurability("memory"), "sf_durability"},
 		{"sf_append_deadline", qdb.WithSfAppendDeadline(10 * time.Second), "sf_append_deadline_millis"},

--- a/examples/qwp/sf/main.go
+++ b/examples/qwp/sf/main.go
@@ -42,7 +42,7 @@ func main() {
 	// sf_dir is the SF group root — one or more sender instances can
 	// share it, each living under <sf_dir>/<sender_id>/.
 	//   sender_id          : per-sender slot name (default "default")
-	//   sf_max_bytes       : per-segment file size (default 4 MiB)
+	//   sf_max_segment_bytes       : per-segment file size (default 4 MiB)
 	//   sf_max_total_bytes : disk cap for THIS sender's slot (default 10 GiB)
 	//   close_flush_timeout_millis : how long Close() waits for ACKs
 	//                                before proceeding (default 5000;
@@ -52,7 +52,7 @@ func main() {
 	conf := "ws::addr=localhost:9000;" +
 		"sf_dir=/var/lib/questdb-sf;" +
 		"sender_id=trades-feed;" +
-		"sf_max_bytes=8388608;" +
+		"sf_max_segment_bytes=8388608;" +
 		"sf_max_total_bytes=1073741824;" + // 1 GiB
 		"close_flush_timeout_millis=5000;" +
 		"drain_orphans=on;"

--- a/qwp_constants.go
+++ b/qwp_constants.go
@@ -273,13 +273,6 @@ const (
 	// Both fire even when the user opted out of byte-size auto-flush.
 	qwpDefaultAutoFlushBytes = 8 * 1024 * 1024
 
-	// qwpDefaultInFlightWindow seeds in_flight_window for Java-parity
-	// config compatibility. The cursor architecture ignores it —
-	// backpressure is governed by the engine's segment ring and append
-	// deadline (see WithInFlightWindow). Java:
-	// QwpWebSocketSender.DEFAULT_IN_FLIGHT_WINDOW_SIZE = 128.
-	qwpDefaultInFlightWindow = 128
-
 	// qwpDefaultMicrobatchBufSize is the per-encoder microbatch buffer
 	// size used to coalesce rows before a WebSocket frame is sent.
 	// Java: QwpWebSocketSender.DEFAULT_MICROBATCH_BUFFER_SIZE = 1 MB.

--- a/qwp_encoder.go
+++ b/qwp_encoder.go
@@ -38,13 +38,6 @@ import "fmt"
 type qwpEncoder struct {
 	wb      qwpWireBuffer
 	gorilla qwpGorillaEncoder
-
-	// gorillaDisabled flips off FLAG_GORILLA in the header and skips
-	// the per-column encoding-flag byte for timestamps. Stored as the
-	// negation so the zero value (0 / false) matches the default of
-	// Gorilla being enabled. Mirrors QwpWebSocketSender's
-	// gorillaEnabled=true default in the Java client.
-	gorillaDisabled bool
 }
 
 // encodeTable encodes a single table buffer into a complete QWP
@@ -140,14 +133,9 @@ func (e *qwpEncoder) encodeMultiTableWithDeltaDict(
 // --- header and payload helpers ---
 
 // headerFlags returns the header flags byte for the current encoder
-// state. FLAG_DELTA_SYMBOL_DICT is always set; FLAG_GORILLA is
-// included unless gorillaDisabled is true.
+// state. QWP ingress always sets FLAG_DELTA_SYMBOL_DICT and FLAG_GORILLA.
 func (e *qwpEncoder) headerFlags() byte {
-	flags := qwpFlagDeltaSymbolDict
-	if !e.gorillaDisabled {
-		flags |= qwpFlagGorilla
-	}
-	return flags
+	return qwpFlagDeltaSymbolDict | qwpFlagGorilla
 }
 
 // writeHeader writes the 12-byte QWP message header with the given
@@ -341,25 +329,19 @@ func (e *qwpEncoder) encodeArrayColumn(col *qwpColumnBuffer) {
 	e.wb.putBytes(col.arrayData)
 }
 
-// encodeTimestampColumn writes a timestamp column's payload. The wire
-// shape depends on whether FLAG_GORILLA is set at the message level:
+// encodeTimestampColumn writes a timestamp column's payload. QWP ingress
+// always sets FLAG_GORILLA at the message level, so the payload is a
+// 1-byte encoding flag (0x01 = Gorilla, 0x00 = uncompressed) followed by
+// the values. Gorilla is used when the column has more than two non-null
+// values and every DoD fits in int32; all other cases fall back to raw
+// int64 LE values, matching QwpColumnWriter.writeTimestampColumn in the
+// Java client.
 //
 // Note: DATE is NOT routed here. Ingestion frames DATE as a plain
 // int64 (matching the Java QwpColumnWriter); only server *egress*
 // frames DATE timestamp-ish. The asymmetry is by protocol design —
 // see the DATE case in qwp_query_decoder.go's parseColumn.
-//
-//   - FLAG_GORILLA on (default): a 1-byte encoding flag (0x01 = Gorilla,
-//     0x00 = uncompressed) followed by the payload. Gorilla is used when
-//     the column has more than two non-null values and every DoD fits in
-//     int32. All other cases fall back to raw int64 LE values, matching
-//     QwpColumnWriter.writeTimestampColumn in the Java client.
-//   - FLAG_GORILLA off: raw int64 LE values with no encoding flag byte.
 func (e *qwpEncoder) encodeTimestampColumn(col *qwpColumnBuffer) {
-	if e.gorillaDisabled {
-		e.wb.putBytes(col.fixedData)
-		return
-	}
 	count := col.valueCount()
 	if count > 2 && qwpGorillaEncodedSize(col.fixedData, count) >= 0 {
 		e.wb.putByte(qwpTsEncodingGorilla)

--- a/qwp_encoder_test.go
+++ b/qwp_encoder_test.go
@@ -1523,50 +1523,6 @@ func TestQwpEncoderTimestampGorillaOverflowFallback(t *testing.T) {
 	}
 }
 
-func TestQwpEncoderGorillaDisabled(t *testing.T) {
-	// When gorillaDisabled is set, FLAG_GORILLA must be clear and
-	// timestamp columns must be raw int64 LE with no encoding-flag
-	// byte — the same wire shape the spec mandates when FLAG_GORILLA
-	// is unset (§12).
-	values := []int64{100, 200, 300, 400, 500}
-	tb := newQwpTableBuffer("t")
-	for _, v := range values {
-		col, _ := tb.getOrCreateColumn("ts", qwpTypeTimestamp, false)
-		col.addTimestamp(v)
-		tb.commitRow()
-	}
-
-	var enc qwpEncoder
-	enc.gorillaDisabled = true
-	msg := enc.encodeTable(tb)
-
-	flags := msg[qwpHeaderOffsetFlags]
-	if flags&qwpFlagGorilla != 0 {
-		t.Fatalf("FLAG_GORILLA must be clear when disabled, got flags=0x%02X", flags)
-	}
-	if flags&qwpFlagDeltaSymbolDict == 0 {
-		t.Fatalf("FLAG_DELTA_SYMBOL_DICT must stay set, got flags=0x%02X", flags)
-	}
-
-	off := qwpHeaderSize + 2 // empty delta dict
-	off += 2                 // table name "t"
-	off++                    // rowCount=5
-	off++                    // colCount=1
-	off += 4                 // column "ts" + type TIMESTAMP
-	off++                    // null bitmap flag (0x00 no nulls)
-
-	// No encoding-flag byte: next 5*8 bytes are the raw values.
-	for i, want := range values {
-		got := int64(binary.LittleEndian.Uint64(msg[off+i*8:]))
-		if got != want {
-			t.Fatalf("ts[%d] = %d, want %d", i, got, want)
-		}
-	}
-	if off+len(values)*8 != len(msg) {
-		t.Fatalf("unexpected trailing bytes: off=%d len=%d", off+len(values)*8, len(msg))
-	}
-}
-
 func TestQwpEncoderMultiTable(t *testing.T) {
 	// Encode 3 tables into a single QWP message and verify the
 	// header has tableCount=3 and all table data is present.

--- a/qwp_error_resilience_test.go
+++ b/qwp_error_resilience_test.go
@@ -563,7 +563,7 @@ func TestErrorApiResilience_SfDiskHaltCloseReopenReplays(t *testing.T) {
 		"ws::addr=" + addrOf(srv),
 		"sf_dir=" + tmp,
 		"sender_id=halt-replay",
-		"sf_max_bytes=4096",
+		"sf_max_segment_bytes=4096",
 		"close_flush_timeout_millis=100;", // short — the loop will halt, not drain
 	}, ";")
 
@@ -623,7 +623,7 @@ func TestErrorApiResilience_SfDiskDropPersistsAckedAcrossRestart(t *testing.T) {
 		"ws::addr=" + addrOf(srv),
 		"sf_dir=" + tmp,
 		"sender_id=drop-restart",
-		"sf_max_bytes=4096",
+		"sf_max_segment_bytes=4096",
 		"close_flush_timeout_millis=2000;",
 	}, ";")
 

--- a/qwp_ingress_oracle_fuzz_test.go
+++ b/qwp_ingress_oracle_fuzz_test.go
@@ -779,11 +779,11 @@ func TestQwpFuzzIngressOracleMultiSender(t *testing.T) {
 
 // --- bounce-torture scenario -----------------------------------------
 
-// oraclePickSfMaxBytes mirrors Java pickSfMaxBytes: small segments force
+// oraclePickSfMaxSegmentBytes mirrors Java pickSfMaxSegmentBytes: small segments force
 // frequent rotation (stresses purge bookkeeping), large segments resemble
 // the production default. The chosen value also scales the post-close
 // slot-purge bound.
-func oraclePickSfMaxBytes(r *rand.Rand) int64 {
+func oraclePickSfMaxSegmentBytes(r *rand.Rand) int64 {
 	pool := []int64{256 * 1024, 1024 * 1024, 4 * 1024 * 1024}
 	return pool[r.Intn(len(pool))]
 }
@@ -871,7 +871,7 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 	producerCount := 2 + r.Intn(3)       // 2..4
 	rowsPerProducer := 300 + r.Intn(400) // 300..699 (CI-bounded)
 	bounces := 2 + r.Intn(3)             // 2..4
-	sfMaxBytes := oraclePickSfMaxBytes(r)
+	sfMaxSegmentBytes := oraclePickSfMaxSegmentBytes(r)
 	batchSizes := make([]int, producerCount)
 	autoFlush := make([]int, producerCount)
 	for p := 0; p < producerCount; p++ {
@@ -880,8 +880,8 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 	}
 	bRnd := rand.New(rand.NewSource(r.Int63()))
 	totalRows := producerCount * rowsPerProducer
-	t.Logf("ingress oracle bounce: producers=%d rows/producer=%d total=%d bounces=%d sf_max_bytes=%d",
-		producerCount, rowsPerProducer, totalRows, bounces, sfMaxBytes)
+	t.Logf("ingress oracle bounce: producers=%d rows/producer=%d total=%d bounces=%d sf_max_segment_bytes=%d",
+		producerCount, rowsPerProducer, totalRows, bounces, sfMaxSegmentBytes)
 
 	srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
 	defer srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
@@ -930,8 +930,8 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 				"ws::addr=%s;sf_dir=%s;initial_connect_retry=async;"+
 					"reconnect_max_duration_millis=120000;"+
 					"close_flush_timeout_millis=120000;"+
-					"sf_max_bytes=%d;auto_flush_rows=%d;",
-				srv.wsAddr(), sfDirs[p], sfMaxBytes, autoFlush[p])
+					"sf_max_segment_bytes=%d;auto_flush_rows=%d;",
+				srv.wsAddr(), sfDirs[p], sfMaxSegmentBytes, autoFlush[p])
 			qs, closeSender := oracleSenderFromConf(t, conf)
 			defer closeSender()
 			ctx := context.Background()
@@ -989,8 +989,8 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 
 	// Clean close ACKed every frame; the SF cursor unlinks rotated
 	// segments. A small residue (lock, ack-watermark, active header) is
-	// normal — Java's slotCapFor is sf_max_bytes + 256 KiB.
-	capBytes := sfMaxBytes + 256*1024
+	// normal — Java's slotCapFor is sf_max_segment_bytes + 256 KiB.
+	capBytes := sfMaxSegmentBytes + 256*1024
 	for p, dir := range sfDirs {
 		sz, err := oracleSfDirSize(dir)
 		if err != nil {
@@ -1054,7 +1054,7 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 	chunksPerProducer := 30 + r.Intn(30)  // 30..59
 	chunkSize := 5 + r.Intn(6)            // 5..10 rows (maps to one frame)
 	const poisonChunkInN = 4              // ~25% of chunks poisoned
-	sfMaxBytes := oraclePickSfMaxBytes(r) // shared with the bounce port
+	sfMaxSegmentBytes := oraclePickSfMaxSegmentBytes(r) // shared with the bounce port
 
 	// Constructible client-side? 2^192 is 58 digits — inside Decimal256's
 	// 76-digit envelope, so NewDecimal accepts it and the rejection is
@@ -1099,8 +1099,8 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 	}
 	cleanRows := len(oracle.rows)
 	t.Logf("ingress oracle poison: producers=%d chunks/producer=%d chunkSize=%d "+
-		"poisonedChunks=%d cleanRows=%d sf_max_bytes=%d",
-		producerCount, chunksPerProducer, chunkSize, totalPoisonedChunks, cleanRows, sfMaxBytes)
+		"poisonedChunks=%d cleanRows=%d sf_max_segment_bytes=%d",
+		producerCount, chunksPerProducer, chunkSize, totalPoisonedChunks, cleanRows, sfMaxSegmentBytes)
 
 	srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
 	defer srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
@@ -1140,7 +1140,7 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 				WithQwp(),
 				WithAddress(srv.wsAddr()),
 				WithSfDir(sfDirs[p]),
-				WithSfMaxBytes(sfMaxBytes),
+				WithSfMaxSegmentBytes(sfMaxSegmentBytes),
 				WithInitialConnectRetry(true), // initial_connect_retry=true (sync)
 				WithCloseFlushTimeout(120*time.Second),
 				WithErrorInboxCapacity(4096),
@@ -1260,8 +1260,8 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 	t.Logf("poison: poisonedChunks=%d handlerCalls=%d", totalPoisonedChunks, got)
 
 	// Clean close ACKed/handled every frame; the SF cursor unlinks
-	// rotated segments. Java's slotCapFor: sf_max_bytes + 256 KiB.
-	capBytes := sfMaxBytes + 256*1024
+	// rotated segments. Java's slotCapFor: sf_max_segment_bytes + 256 KiB.
+	capBytes := sfMaxSegmentBytes + 256*1024
 	for p, dir := range sfDirs {
 		sz, err := oracleSfDirSize(dir)
 		if err != nil {
@@ -1312,15 +1312,15 @@ func TestQwpFuzzIngressOracleSenderRestartReplay(t *testing.T) {
 	producerCount := 2 + r.Intn(2)       // 2..3
 	rowsPerProducer := 300 + r.Intn(400) // 300..699 (CI-bounded)
 	bounces := 1 + r.Intn(2)             // 1..2
-	sfMaxBytes := oraclePickSfMaxBytes(r)
+	sfMaxSegmentBytes := oraclePickSfMaxSegmentBytes(r)
 	lifetimeSeeds := make([]int64, producerCount)
 	for p := 0; p < producerCount; p++ {
 		lifetimeSeeds[p] = r.Int63()
 	}
 	bRnd := rand.New(rand.NewSource(r.Int63()))
 	totalRows := producerCount * rowsPerProducer
-	t.Logf("ingress oracle restart-replay: producers=%d rows/producer=%d total=%d bounces=%d sf_max_bytes=%d",
-		producerCount, rowsPerProducer, totalRows, bounces, sfMaxBytes)
+	t.Logf("ingress oracle restart-replay: producers=%d rows/producer=%d total=%d bounces=%d sf_max_segment_bytes=%d",
+		producerCount, rowsPerProducer, totalRows, bounces, sfMaxSegmentBytes)
 
 	srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
 	defer srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
@@ -1388,8 +1388,8 @@ func TestQwpFuzzIngressOracleSenderRestartReplay(t *testing.T) {
 			loopConf := fmt.Sprintf(
 				"ws::addr=%s;sf_dir=%s;initial_connect_retry=async;"+
 					"reconnect_max_duration_millis=120000;"+
-					"sf_max_bytes=%d;close_flush_timeout_millis=0;",
-				srv.wsAddr(), sfDirs[p], sfMaxBytes)
+					"sf_max_segment_bytes=%d;close_flush_timeout_millis=0;",
+				srv.wsAddr(), sfDirs[p], sfMaxSegmentBytes)
 			written := 0
 			for written < len(rows) {
 				chunk := 30 + lifeR.Intn(200) // 30..229 rows per sender
@@ -1421,8 +1421,8 @@ func TestQwpFuzzIngressOracleSenderRestartReplay(t *testing.T) {
 			drainConf := fmt.Sprintf(
 				"ws::addr=%s;sf_dir=%s;initial_connect_retry=async;"+
 					"reconnect_max_duration_millis=120000;"+
-					"sf_max_bytes=%d;close_flush_timeout_millis=120000;",
-				srv.wsAddr(), sfDirs[p], sfMaxBytes)
+					"sf_max_segment_bytes=%d;close_flush_timeout_millis=120000;",
+				srv.wsAddr(), sfDirs[p], sfMaxSegmentBytes)
 			qs, err := openSender(p, drainConf)
 			if err != nil {
 				errs[p] = err
@@ -1468,7 +1468,7 @@ func TestQwpFuzzIngressOracleSenderRestartReplay(t *testing.T) {
 	c := newBindFuzzClient(t, srv)
 	oracleAssert(t, c, oracle)
 
-	capBytes := sfMaxBytes + 256*1024
+	capBytes := sfMaxSegmentBytes + 256*1024
 	for p, dir := range sfDirs {
 		sz, err := oracleSfDirSize(dir)
 		if err != nil {
@@ -1536,10 +1536,10 @@ func TestQwpFuzzIngressOracleAsyncConnectQueues(t *testing.T) {
 	r := newFuzzRand(t)
 	producerCount := 2 + r.Intn(2)       // 2..3
 	rowsPerProducer := 250 + r.Intn(400) // 250..649 (CI-bounded)
-	sfMaxBytes := oraclePickSfMaxBytes(r)
+	sfMaxSegmentBytes := oraclePickSfMaxSegmentBytes(r)
 	totalRows := producerCount * rowsPerProducer
-	t.Logf("ingress oracle async-connect: producers=%d rows/producer=%d total=%d sf_max_bytes=%d",
-		producerCount, rowsPerProducer, totalRows, sfMaxBytes)
+	t.Logf("ingress oracle async-connect: producers=%d rows/producer=%d total=%d sf_max_segment_bytes=%d",
+		producerCount, rowsPerProducer, totalRows, sfMaxSegmentBytes)
 
 	srv.mustExec(t, "DROP TABLE IF EXISTS '"+oracleTableName+"'")
 	srv.mustExec(t, oracleCreateSQL)
@@ -1593,9 +1593,9 @@ func TestQwpFuzzIngressOracleAsyncConnectQueues(t *testing.T) {
 					"reconnect_max_duration_millis=120000;"+
 					"reconnect_initial_backoff_millis=20;"+
 					"reconnect_max_backoff_millis=200;"+
-					"sf_max_bytes=%d;"+
+					"sf_max_segment_bytes=%d;"+
 					"close_flush_timeout_millis=120000;",
-				srv.wsAddr(), sfDirs[p], sfMaxBytes)
+				srv.wsAddr(), sfDirs[p], sfMaxSegmentBytes)
 
 			// Time the constructor: async mode must return promptly
 			// even when no server listens — the whole point.
@@ -1727,7 +1727,7 @@ func TestQwpFuzzIngressOracleAsyncConnectQueues(t *testing.T) {
 	c := newBindFuzzClient(t, srv)
 	oracleAssert(t, c, oracle)
 
-	capBytes := sfMaxBytes + 256*1024
+	capBytes := sfMaxSegmentBytes + 256*1024
 	for p, dir := range sfDirs {
 		sz, err := oracleSfDirSize(dir)
 		if err != nil {

--- a/qwp_integration_test.go
+++ b/qwp_integration_test.go
@@ -473,8 +473,7 @@ func TestQwpIntegrationAsyncMode(t *testing.T) {
 	qwpDropTable(t, tableName)
 	defer qwpDropTable(t, tableName)
 
-	// Create sender with in-flight window = 4.
-	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 4)
+	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,7 +518,7 @@ func TestQwpIntegrationAsyncFromConf(t *testing.T) {
 	qwpDropTable(t, tableName)
 	defer qwpDropTable(t, tableName)
 
-	confStr := fmt.Sprintf("ws::addr=%s;auto_flush=off;in_flight_window=2;", qwpTestAddr)
+	confStr := fmt.Sprintf("ws::addr=%s;auto_flush=off;", qwpTestAddr)
 	sender, err := LineSenderFromConf(ctx, confStr)
 	if err != nil {
 		t.Fatalf("LineSenderFromConf: %v", err)
@@ -1902,8 +1901,8 @@ func TestQwpIntegrationAsyncCloseFlushes(t *testing.T) {
 	qwpDropTable(t, tableName)
 	defer qwpDropTable(t, tableName)
 
-	// Async sender (in-flight window = 4). No explicit Flush.
-	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 4)
+	// Async sender. No explicit Flush.
+	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -1945,9 +1944,9 @@ func TestQwpIntegrationAsyncStressAcks(t *testing.T) {
 	qwpDropTable(t, tableName)
 	defer qwpDropTable(t, tableName)
 
-	// autoFlushRows=2 → 50 batches in flight for 100 rows, with the
-	// default in-flight window the sender must recycle buffers via ACKs.
-	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 2, 0, nil, 4)
+	// autoFlushRows=2 -> 50 batches in flight for 100 rows; the
+	// sender recycles buffers via ACKs as the engine drains.
+	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 2, 0, nil)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -1989,7 +1988,7 @@ func TestQwpIntegrationAsyncMultiTable(t *testing.T) {
 	defer qwpDropTable(t, tableA)
 	defer qwpDropTable(t, tableB)
 
-	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 4)
+	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -2037,8 +2036,8 @@ func TestQwpIntegrationAsyncRowBasedFlush(t *testing.T) {
 	qwpDropTable(t, tableName)
 	defer qwpDropTable(t, tableName)
 
-	// autoFlushRows=10, so 50 rows → 5 automatic flushes in async mode.
-	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil, 4)
+	// autoFlushRows=10, so 50 rows -> 5 automatic flushes in async mode.
+	s, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil)
 	if err != nil {
 		t.Fatalf("connect: %v", err)
 	}
@@ -2096,7 +2095,7 @@ func TestQwpIntegrationConcurrentSenders(t *testing.T) {
 		for s := 0; s < senderCount; s++ {
 			go func(idx int) {
 				defer wg.Done()
-				sender, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil, 4)
+				sender, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil)
 				if err != nil {
 					errs <- fmt.Errorf("sender %d connect: %w", idx, err)
 					return
@@ -2147,7 +2146,7 @@ func TestQwpIntegrationConcurrentSenders(t *testing.T) {
 		for s := 0; s < senderCount; s++ {
 			go func(idx int) {
 				defer wg.Done()
-				sender, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil, 4)
+				sender, err := newQwpLineSender(ctx, "ws://"+qwpTestAddr, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil)
 				if err != nil {
 					errs <- fmt.Errorf("sender %d connect: %w", idx, err)
 					return

--- a/qwp_query_client.go
+++ b/qwp_query_client.go
@@ -280,13 +280,6 @@ func WithQwpQueryEndpointPath(path string) QwpQueryClientOption {
 	return func(c *qwpQueryClientConfig) { c.endpointPath = path }
 }
 
-// WithQwpQueryAuth sets the raw Authorization HTTP header value sent
-// on the WebSocket upgrade. Mutually exclusive with
-// WithQwpQueryBasicAuth and WithQwpQueryBearerToken.
-func WithQwpQueryAuth(authHeader string) QwpQueryClientOption {
-	return func(c *qwpQueryClientConfig) { c.authorization = authHeader }
-}
-
 // WithQwpQueryBasicAuth enables HTTP Basic authentication. The server
 // validates against the same user store that the Postgres wire
 // protocol uses — a user created via CREATE USER ... WITH PASSWORD ...
@@ -715,12 +708,9 @@ func probeZstdAvailable() error {
 }
 
 // effectiveAuthorization computes the Authorization header value
-// from the config, resolving the three mutually-exclusive auth modes
+// from the config, resolving the two mutually-exclusive auth modes
 // into a single header string.
 func (c *qwpQueryClientConfig) effectiveAuthorization() string {
-	if c.authorization != "" {
-		return c.authorization
-	}
 	if c.httpUser != "" && c.httpPass != "" {
 		creds := c.httpUser + ":" + c.httpPass
 		return "Basic " + base64.StdEncoding.EncodeToString([]byte(creds))

--- a/qwp_query_client.go
+++ b/qwp_query_client.go
@@ -444,6 +444,17 @@ func WithQwpQueryAuthTimeout(d time.Duration) QwpQueryClientOption {
 	}
 }
 
+// WithQwpQueryConnectTimeout bounds each TCP connect attempt. It does
+// not cover the TLS handshake, WebSocket upgrade-response read (see
+// WithQwpQueryAuthTimeout), or SERVER_INFO read. Zero leaves the
+// connect bounded by the operating system; negative durations are
+// rejected by validate().
+func WithQwpQueryConnectTimeout(d time.Duration) QwpQueryClientOption {
+	return func(c *qwpQueryClientConfig) {
+		c.connectTimeoutMs = int(d.Milliseconds())
+	}
+}
+
 // WithQwpQueryReplayExec opts Exec into transparent replay on
 // transport-terminal failure. Default false because non-idempotent
 // statements (INSERT / UPDATE / DELETE / DDL) might double-execute

--- a/qwp_query_client.go
+++ b/qwp_query_client.go
@@ -451,6 +451,13 @@ func WithQwpQueryAuthTimeout(d time.Duration) QwpQueryClientOption {
 // rejected by validate().
 func WithQwpQueryConnectTimeout(d time.Duration) QwpQueryClientOption {
 	return func(c *qwpQueryClientConfig) {
+		if d < 0 {
+			// A sub-millisecond negative truncates to 0 under
+			// d.Milliseconds() and would read as the zero (OS-default)
+			// case, so map every negative to a value validate() rejects.
+			c.connectTimeoutMs = -1
+			return
+		}
 		c.connectTimeoutMs = int(d.Milliseconds())
 	}
 }

--- a/qwp_query_client_test.go
+++ b/qwp_query_client_test.go
@@ -714,6 +714,7 @@ func TestQwpQueryClientOptionsApply(t *testing.T) {
 		WithQwpQueryCompression(qwpCompressionZstd),
 		WithQwpQueryCompressionLevel(9),
 		WithQwpQueryFailoverMaxDuration(7 * time.Second),
+		WithQwpQueryConnectTimeout(3 * time.Second),
 	} {
 		opt(cfg)
 	}
@@ -752,6 +753,9 @@ func TestQwpQueryClientOptionsApply(t *testing.T) {
 	}
 	if cfg.failoverMaxDuration != 7*time.Second {
 		t.Errorf("failoverMaxDuration=%v, want 7s", cfg.failoverMaxDuration)
+	}
+	if cfg.connectTimeoutMs != 3000 {
+		t.Errorf("connectTimeoutMs=%d, want 3000", cfg.connectTimeoutMs)
 	}
 }
 

--- a/qwp_query_client_test.go
+++ b/qwp_query_client_test.go
@@ -141,18 +141,6 @@ func TestQwpQueryClientFromConfHappyPath(t *testing.T) {
 			},
 		},
 		{
-			name: "auth_header",
-			conf: "ws::addr=a:1;auth=Bearer abc;",
-			chk: func(t *testing.T, c *qwpQueryClientConfig) {
-				if c.authorization != "Bearer abc" {
-					t.Errorf("authorization=%q", c.authorization)
-				}
-				if got := c.effectiveAuthorization(); got != "Bearer abc" {
-					t.Errorf("effectiveAuthorization=%q", got)
-				}
-			},
-		},
-		{
 			name: "bearer_token",
 			conf: "ws::addr=a:1;token=xyz;",
 			chk: func(t *testing.T, c *qwpQueryClientConfig) {
@@ -246,8 +234,9 @@ func TestQwpQueryClientFromConfErrors(t *testing.T) {
 		{"buffer_pool_zero", "ws::addr=a:1;buffer_pool_size=0;", "buffer pool size must be >= 1"},
 		{"max_batch_rows_negative", "ws::addr=a:1;max_batch_rows=-1;", "max batch rows must be >= 0"},
 		{"max_batch_rows_too_big", "ws::addr=a:1;max_batch_rows=99999999;", "exceeds client cap"},
-		{"mutually_exclusive_auth", "ws::addr=a:1;auth=X;token=Y;", "mutually exclusive"},
+		{"mutually_exclusive_basic_token", "ws::addr=a:1;username=u;password=p;token=Y;", "mutually exclusive"},
 		{"basic_missing_password", "ws::addr=a:1;username=u;", "both username and password"},
+		{"auth_key_removed", "ws::addr=a:1;auth=Bearer abc;", "unsupported option"},
 		{"unknown_key", "ws::addr=a:1;weird=1;", "unsupported option"},
 		{"tls_on_ws", "ws::addr=a:1;tls_verify=on;", "tls_verify requires"},
 		{"tls_bad", "wss::addr=a:1;tls_verify=off;", "invalid tls_verify"},

--- a/qwp_query_client_test.go
+++ b/qwp_query_client_test.go
@@ -759,6 +759,32 @@ func TestQwpQueryClientOptionsApply(t *testing.T) {
 	}
 }
 
+// TestQwpQueryConnectTimeoutNegative pins that a negative duration keeps
+// connectTimeoutMs negative so validate() rejects it. A sub-millisecond
+// negative truncates to 0 under d.Milliseconds() and would otherwise read
+// as the valid zero (OS-default) case, bypassing validation.
+func TestQwpQueryConnectTimeoutNegative(t *testing.T) {
+	for _, d := range []time.Duration{
+		-500 * time.Microsecond, // truncates to 0 ms
+		-1 * time.Nanosecond,    // truncates to 0 ms
+		-5 * time.Millisecond,   // already negative in ms
+	} {
+		cfg := qwpQueryDefaultConfig()
+		WithQwpQueryConnectTimeout(d)(cfg)
+		if cfg.connectTimeoutMs >= 0 {
+			t.Errorf("connectTimeoutMs=%d for d=%v, want negative so validate() rejects it",
+				cfg.connectTimeoutMs, d)
+		}
+	}
+
+	// A zero duration stays the valid zero (OS-default) case.
+	cfg := qwpQueryDefaultConfig()
+	WithQwpQueryConnectTimeout(0)(cfg)
+	if cfg.connectTimeoutMs != 0 {
+		t.Errorf("connectTimeoutMs=%d for a zero duration, want 0", cfg.connectTimeoutMs)
+	}
+}
+
 // --- Mock server integration tests for the public API ---
 
 // newMockQueryClient stands up the egress mock server, dials it with a

--- a/qwp_query_conf.go
+++ b/qwp_query_conf.go
@@ -47,16 +47,12 @@ type qwpQueryClientConfig struct {
 	// endpointPath is the HTTP path used for the WebSocket upgrade.
 	// Default "/read/v1".
 	endpointPath string
-	// authorization, when non-empty, is sent verbatim as the
-	// Authorization HTTP header. Mutually exclusive with user/pass and
-	// token.
-	authorization string
 	// httpUser / httpPass populate an HTTP Basic Authorization header
-	// at connect time. Mutually exclusive with authorization and token.
+	// at connect time. Mutually exclusive with token.
 	httpUser string
 	httpPass string
 	// httpToken populates a Bearer Authorization header at connect
-	// time. Mutually exclusive with authorization and user/pass.
+	// time. Mutually exclusive with user/pass.
 	httpToken string
 	// clientID overrides the default X-QWP-Client-Id header. Empty
 	// uses the module default (qwpClientId).
@@ -286,18 +282,8 @@ func (c *qwpQueryClientConfig) validate() error {
 			c.compressionLevel)
 	}
 	basicSet := c.httpUser != "" || c.httpPass != ""
-	authModes := 0
-	if c.authorization != "" {
-		authModes++
-	}
-	if basicSet {
-		authModes++
-	}
-	if c.httpToken != "" {
-		authModes++
-	}
-	if authModes > 1 {
-		return fmt.Errorf("qwp query: auth, username/password, and token are mutually exclusive")
+	if basicSet && c.httpToken != "" {
+		return fmt.Errorf("qwp query: username/password and token are mutually exclusive")
 	}
 	if basicSet && (c.httpUser == "" || c.httpPass == "") {
 		return fmt.Errorf("qwp query: both username and password must be provided together")
@@ -438,8 +424,6 @@ func parseQwpQueryConf(conf string) (*qwpQueryClientConfig, error) {
 			cfg.endpoints = eps
 		case "path":
 			cfg.endpointPath = v
-		case "auth":
-			cfg.authorization = v
 		case "username":
 			cfg.httpUser = v
 		case "password":

--- a/qwp_query_conf.go
+++ b/qwp_query_conf.go
@@ -106,6 +106,9 @@ type qwpQueryClientConfig struct {
 	// SERVER_INFO frame read (that uses serverInfoTimeout). Default
 	// qwpDefaultAuthTimeoutMs (15_000); must be > 0.
 	authTimeoutMs int
+	// connectTimeoutMs bounds each TCP connect attempt. Zero leaves the
+	// connect bounded by the OS; an explicit config value must be > 0.
+	connectTimeoutMs int
 	// failoverEnabled toggles transparent reconnect-and-replay on
 	// transport-terminal failure mid-query. Default true; matches
 	// Java's failover=on default. When false, transport errors
@@ -320,6 +323,10 @@ func (c *qwpQueryClientConfig) validate() error {
 		return fmt.Errorf(
 			"qwp query: auth_timeout_ms must be > 0, got %d", c.authTimeoutMs)
 	}
+	if c.connectTimeoutMs < 0 {
+		return fmt.Errorf(
+			"qwp query: connect_timeout must be >= 0, got %d", c.connectTimeoutMs)
+	}
 	if c.target > qwpTargetReplica {
 		return fmt.Errorf("qwp query: invalid target %d (expected any, primary, or replica)",
 			byte(c.target))
@@ -504,6 +511,12 @@ func parseQwpQueryConf(conf string) (*qwpQueryClientConfig, error) {
 					"auth_timeout_ms must be > 0, got %d", n)
 			}
 			cfg.authTimeoutMs = n
+		case "connect_timeout":
+			n, err := parseConnectTimeoutMillis(v)
+			if err != nil {
+				return nil, err
+			}
+			cfg.connectTimeoutMs = n
 		case "failover":
 			switch v {
 			case "on":

--- a/qwp_query_failover.go
+++ b/qwp_query_failover.go
@@ -323,6 +323,7 @@ func connectWalk(ctx context.Context, cfg *qwpQueryClientConfig, tracker *qwpHos
 			maxVersion:        qwpVersion,
 			serverInfoTimeout: cfg.serverInfoTimeout,
 			authTimeoutMs:     cfg.authTimeoutMs,
+			connectTimeoutMs:  cfg.connectTimeoutMs,
 		}
 		attempts++
 		if err := tr.connect(ctx, wsURL, opts); err != nil {

--- a/qwp_sender.go
+++ b/qwp_sender.go
@@ -360,11 +360,6 @@ type qwpLineSender struct {
 	// Maximum length for table and column names.
 	fileNameLimit int
 
-	// inFlightWindow is retained as a config knob for backwards
-	// compat but is a no-op in cursor mode — the engine handles
-	// concurrency via its own backpressure model.
-	inFlightWindow int
-
 	// cursorEngine + cursorSendLoop are set on every sender. The
 	// engine is memory-backed when sf_dir is empty and disk-backed
 	// otherwise. The send loop owns the WebSocket connection;
@@ -393,15 +388,12 @@ type qwpLineSender struct {
 // newQwpLineSender creates a new QWP sender backed by an
 // in-memory cursor engine. The send loop establishes the
 // WebSocket connection synchronously; on failure, the constructor
-// returns the dial / upgrade error directly. inFlightWindow is
-// accepted for backwards compatibility but is a no-op (the cursor
-// engine handles concurrency via its own backpressure model). If
-// dumpWriter is non-nil, outgoing bytes are recorded across every
-// transport instance the send loop creates (initial connect plus
-// reconnects).
-func newQwpLineSender(ctx context.Context, address string, opts qwpTransportOpts, autoFlushRows int, autoFlushInterval time.Duration, dumpWriter io.Writer, inFlightWindow ...int) (*qwpLineSender, error) {
+// returns the dial / upgrade error directly. If dumpWriter is
+// non-nil, outgoing bytes are recorded across every transport
+// instance the send loop creates (initial connect plus reconnects).
+func newQwpLineSender(ctx context.Context, address string, opts qwpTransportOpts, autoFlushRows int, autoFlushInterval time.Duration, dumpWriter io.Writer) (*qwpLineSender, error) {
 	s, err := newQwpLineSenderUnstarted(ctx, address, opts,
-		autoFlushRows, autoFlushInterval, dumpWriter, inFlightWindow...)
+		autoFlushRows, autoFlushInterval, dumpWriter)
 	if err != nil {
 		return nil, err
 	}
@@ -416,12 +408,7 @@ func newQwpLineSender(ctx context.Context, address string, opts qwpTransportOpts
 // the very first received frame races against the post-construction
 // setters and could be classified with the default resolver / handled
 // by the default handler instead of the user-configured ones.
-func newQwpLineSenderUnstarted(ctx context.Context, address string, opts qwpTransportOpts, autoFlushRows int, autoFlushInterval time.Duration, dumpWriter io.Writer, inFlightWindow ...int) (*qwpLineSender, error) {
-	window := 1
-	if len(inFlightWindow) > 0 && inFlightWindow[0] > 1 {
-		window = inFlightWindow[0]
-	}
-
+func newQwpLineSenderUnstarted(ctx context.Context, address string, opts qwpTransportOpts, autoFlushRows int, autoFlushInterval time.Duration, dumpWriter io.Writer) (*qwpLineSender, error) {
 	s := &qwpLineSender{
 		tableBuffers:      make(map[string]*qwpTableBuffer),
 		globalSymbols:     make(map[string]int32),
@@ -429,7 +416,6 @@ func newQwpLineSenderUnstarted(ctx context.Context, address string, opts qwpTran
 		batchMaxSymbolId:  -1,
 		autoFlushRows:     autoFlushRows,
 		autoFlushInterval: autoFlushInterval,
-		inFlightWindow:    window,
 		closeTimeout:      5 * time.Second,
 	}
 	s.encoder.wb.preallocate(qwpDefaultMicrobatchBufSize)

--- a/qwp_sender_cursor.go
+++ b/qwp_sender_cursor.go
@@ -98,7 +98,6 @@ func newQwpCursorLineSender(
 		autoFlushInterval: autoFlushInterval,
 		autoFlushBytes:    autoFlushBytes,
 		maxBufSize:        maxBufSize,
-		inFlightWindow:    1,
 		closeTimeout:      closeFlushTimeout,
 		cursorEngine:      cursorEngine,
 		cursorSendLoop:    cursorSendLoop,

--- a/qwp_sender_cursor.go
+++ b/qwp_sender_cursor.go
@@ -303,7 +303,6 @@ func newQwpCursorLineSenderFromConf(ctx context.Context, conf *lineSenderConfig,
 		return nil, err
 	}
 	s.fileNameLimit = conf.fileNameLimit
-	s.encoder.gorillaDisabled = conf.gorillaDisabled
 	// Pre-size the encoder buffer for the microbatch role: the cursor
 	// engine copies each frame on append so one encoder slot suffices,
 	// but a large auto_flush_bytes warrants a bigger initial buffer to

--- a/qwp_sender_cursor.go
+++ b/qwp_sender_cursor.go
@@ -143,9 +143,9 @@ func newQwpCursorLineSenderFromConf(ctx context.Context, conf *lineSenderConfig,
 	if senderId == "" {
 		senderId = qwpSfDefaultSenderId
 	}
-	sfMaxBytes := conf.sfMaxBytes
-	if sfMaxBytes <= 0 {
-		sfMaxBytes = qwpSfDefaultMaxBytes
+	sfMaxSegmentBytes := conf.sfMaxSegmentBytes
+	if sfMaxSegmentBytes <= 0 {
+		sfMaxSegmentBytes = qwpSfDefaultMaxBytes
 	}
 	sfMaxTotalBytes := conf.sfMaxTotalBytes
 	if sfMaxTotalBytes <= 0 {
@@ -154,11 +154,11 @@ func newQwpCursorLineSenderFromConf(ctx context.Context, conf *lineSenderConfig,
 			sfMaxTotalBytes = qwpSfDefaultMemoryMaxTotalBytes
 		}
 	}
-	if sfMaxTotalBytes < sfMaxBytes {
+	if sfMaxTotalBytes < sfMaxSegmentBytes {
 		// Caught earlier in sanitizeQwpConf, but defend in depth
 		// since defaults could in principle skew this.
-		return nil, fmt.Errorf("sf_max_total_bytes (%d) must be >= sf_max_bytes (%d)",
-			sfMaxTotalBytes, sfMaxBytes)
+		return nil, fmt.Errorf("sf_max_total_bytes (%d) must be >= sf_max_segment_bytes (%d)",
+			sfMaxTotalBytes, sfMaxSegmentBytes)
 	}
 	appendDeadline := time.Duration(conf.sfAppendDeadlineMillis) * time.Millisecond
 	if appendDeadline <= 0 {
@@ -192,7 +192,7 @@ func newQwpCursorLineSenderFromConf(ctx context.Context, conf *lineSenderConfig,
 
 	// Build the cursor engine first — it owns the slot lock and on-disk
 	// recovery.
-	engine, err := qwpSfNewCursorEngine(slotPath, sfMaxBytes, sfMaxTotalBytes, appendDeadline)
+	engine, err := qwpSfNewCursorEngine(slotPath, sfMaxSegmentBytes, sfMaxTotalBytes, appendDeadline)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func newQwpCursorLineSenderFromConf(ctx context.Context, conf *lineSenderConfig,
 			for _, orphan := range orphans {
 				drainer := qwpSfNewOrphanDrainer(
 					orphan,
-					sfMaxBytes, sfMaxTotalBytes,
+					sfMaxSegmentBytes, sfMaxTotalBytes,
 					factory,
 					tracker,
 					reconnectMaxDuration, reconnectInitialBackoff, reconnectMaxBackoff,
@@ -658,7 +658,7 @@ func (s *qwpLineSender) oversizeTableError(kind qwpFrameCapKind, capVal int64, m
 			tables, msgSize, capVal, droppedRows)
 	default: // qwpFrameCapSegment
 		return fmt.Errorf(
-			"qwp: batch too large to fit one cursor segment, even split per table [oversizeTables=%v, messageSize=%d, maxFrameBytes=%d, droppedRows=%d]; send fewer rows per flush (or raise sf_max_bytes)",
+			"qwp: batch too large to fit one cursor segment, even split per table [oversizeTables=%v, messageSize=%d, maxFrameBytes=%d, droppedRows=%d]; send fewer rows per flush (or raise sf_max_segment_bytes)",
 			tables, msgSize, capVal, droppedRows)
 	}
 }

--- a/qwp_sender_test.go
+++ b/qwp_sender_test.go
@@ -1755,7 +1755,7 @@ func TestQwpSenderAsyncBasic(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 2)
+	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1819,7 +1819,7 @@ func TestQwpSenderAsyncMultipleFlushes(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 3)
+	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1853,7 +1853,7 @@ func TestQwpSenderAsyncCloseAutoFlush(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 2)
+	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1897,7 +1897,7 @@ func TestQwpAsyncSenderTerminalOnFlushFailure(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil, 2)
+	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 0, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1961,8 +1961,8 @@ func TestQwpAsyncAutoFlushNonBlocking(t *testing.T) {
 	defer srv.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	// window=4, autoFlushRows=10
-	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil, 4)
+	// autoFlushRows=10
+	s, err := newQwpLineSender(context.Background(), wsURL, qwpTransportOpts{endpointPath: qwpWritePath}, 10, 0, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/qwp_sender_test.go
+++ b/qwp_sender_test.go
@@ -2550,3 +2550,30 @@ func TestQwpSenderObservabilityCounters(t *testing.T) {
 		t.Fatalf("BackgroundDrainers after clean flush = %v, want nil", got)
 	}
 }
+
+// TestQwpConnectTimeoutNegative pins that a negative duration keeps
+// connectTimeoutMs negative so sanitizeQwpConf rejects it. A
+// sub-millisecond negative truncates to 0 under d/time.Millisecond and
+// would otherwise read as the valid zero (OS-default) case, bypassing
+// the construction-time check.
+func TestQwpConnectTimeoutNegative(t *testing.T) {
+	for _, d := range []time.Duration{
+		-500 * time.Microsecond, // truncates to 0 ms
+		-1 * time.Nanosecond,    // truncates to 0 ms
+		-5 * time.Millisecond,   // already negative in ms
+	} {
+		cfg := newLineSenderConfig(qwpSenderType)
+		WithConnectTimeout(d)(cfg)
+		if cfg.connectTimeoutMs >= 0 {
+			t.Errorf("connectTimeoutMs=%d for d=%v, want negative so sanitizeQwpConf rejects it",
+				cfg.connectTimeoutMs, d)
+		}
+	}
+
+	// A zero duration stays the valid zero (OS-default) case.
+	cfg := newLineSenderConfig(qwpSenderType)
+	WithConnectTimeout(0)(cfg)
+	if cfg.connectTimeoutMs != 0 {
+		t.Errorf("connectTimeoutMs=%d for a zero duration, want 0", cfg.connectTimeoutMs)
+	}
+}

--- a/qwp_sf_conf_test.go
+++ b/qwp_sf_conf_test.go
@@ -43,7 +43,7 @@ func TestSfConfParseAcceptsAllKnobs(t *testing.T) {
 		"ws::addr=localhost:9000",
 		"sf_dir=/tmp/sf",
 		"sender_id=my-sender",
-		"sf_max_bytes=8388608",
+		"sf_max_segment_bytes=8388608",
 		"sf_max_total_bytes=21474836480",
 		"sf_durability=memory",
 		"sf_append_deadline_millis=20000",
@@ -60,7 +60,7 @@ func TestSfConfParseAcceptsAllKnobs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/sf", conf.sfDir)
 	assert.Equal(t, "my-sender", conf.senderId)
-	assert.Equal(t, int64(8388608), conf.sfMaxBytes)
+	assert.Equal(t, int64(8388608), conf.sfMaxSegmentBytes)
 	assert.Equal(t, int64(21474836480), conf.sfMaxTotalBytes)
 	assert.Equal(t, "memory", conf.sfDurability)
 	assert.Equal(t, 20000, conf.sfAppendDeadlineMillis)
@@ -240,7 +240,7 @@ func TestSfConfDurableAckKeepaliveParses(t *testing.T) {
 
 func TestSfConfRejectsNegativeNumbers(t *testing.T) {
 	cases := []string{
-		"sf_max_bytes=-1",
+		"sf_max_segment_bytes=-1",
 		"sf_max_total_bytes=-1",
 		"sf_append_deadline_millis=0",
 		"reconnect_initial_backoff_millis=0",
@@ -255,55 +255,55 @@ func TestSfConfRejectsNegativeNumbers(t *testing.T) {
 	}
 }
 
-// TestSfConfMaxBytesZeroMeansDefault pins that sf_max_bytes=0 and
+// TestSfConfMaxBytesZeroMeansDefault pins that sf_max_segment_bytes=0 and
 // sf_max_total_bytes=0 are accepted as the "use the default" sentinel,
 // parsing to 0 and resolving to qwpSfDefaultMaxBytes /
 // qwpSfDefaultMaxTotalBytes at construction. This matches the
-// WithSfMaxBytes(0) / WithSfMaxTotalBytes(0) option path and the
+// WithSfMaxSegmentBytes(0) / WithSfMaxTotalBytes(0) option path and the
 // error_inbox_capacity=0 convention.
 func TestSfConfMaxBytesZeroMeansDefault(t *testing.T) {
-	conf, err := confFromStr("ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_bytes=0;sf_max_total_bytes=0;")
+	conf, err := confFromStr("ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_segment_bytes=0;sf_max_total_bytes=0;")
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), conf.sfMaxBytes)
+	assert.Equal(t, int64(0), conf.sfMaxSegmentBytes)
 	assert.Equal(t, int64(0), conf.sfMaxTotalBytes)
 
-	// Builder parity: WithSfMaxBytes(0) / WithSfMaxTotalBytes(0) also
+	// Builder parity: WithSfMaxSegmentBytes(0) / WithSfMaxTotalBytes(0) also
 	// pass sanitization as the use-default sentinel.
 	optConf := newLineSenderConfig(qwpSenderType)
 	WithAddress("localhost:9000")(optConf)
 	WithSfDir("/tmp/sf")(optConf)
-	WithSfMaxBytes(0)(optConf)
+	WithSfMaxSegmentBytes(0)(optConf)
 	WithSfMaxTotalBytes(0)(optConf)
 	require.NoError(t, sanitizeQwpConf(optConf))
 }
 
-// TestSfConfRejectsAutoFlushBytesAboveSfMaxBytes pins the sanitize-time
+// TestSfConfRejectsAutoFlushBytesAboveSfMaxSegmentBytes pins the sanitize-time
 // validation: an explicitly-set auto_flush_bytes that exceeds an
-// explicitly-set sf_max_bytes is rejected, because the byte trigger
+// explicitly-set sf_max_segment_bytes is rejected, because the byte trigger
 // would let a batch grow until its encoded frame can no longer fit a
 // single segment — an un-flushable pairing. The check is at sanitize,
 // not parse, so it runs for both the connect-string and option paths.
-func TestSfConfRejectsAutoFlushBytesAboveSfMaxBytes(t *testing.T) {
+func TestSfConfRejectsAutoFlushBytesAboveSfMaxSegmentBytes(t *testing.T) {
 	conf, err := confFromStr(
-		"ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_bytes=1048576;auto_flush_bytes=2097152;")
+		"ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_segment_bytes=1048576;auto_flush_bytes=2097152;")
 	require.NoError(t, err, "parser accepts both values; the contradiction is caught at sanitize")
 	require.True(t, conf.autoFlushBytesSet)
 
 	err = sanitizeQwpConf(conf)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "auto_flush_bytes")
-	require.Contains(t, err.Error(), "sf_max_bytes")
+	require.Contains(t, err.Error(), "sf_max_segment_bytes")
 }
 
-// TestSfConfRejectsAutoFlushBytesAboveSfMaxBytesViaOptions covers the
+// TestSfConfRejectsAutoFlushBytesAboveSfMaxSegmentBytesViaOptions covers the
 // functional-option set-site: WithAutoFlushBytes must record the
 // explicit-set flag so the same sanitize guard fires.
-func TestSfConfRejectsAutoFlushBytesAboveSfMaxBytesViaOptions(t *testing.T) {
+func TestSfConfRejectsAutoFlushBytesAboveSfMaxSegmentBytesViaOptions(t *testing.T) {
 	conf := newLineSenderConfig(qwpSenderType)
 	for _, opt := range []LineSenderOption{
 		WithAddress("localhost:9000"),
 		WithSfDir("/tmp/sf"),
-		WithSfMaxBytes(1 << 20),
+		WithSfMaxSegmentBytes(1 << 20),
 		WithAutoFlushBytes(2 << 20),
 	} {
 		opt(conf)
@@ -313,32 +313,32 @@ func TestSfConfRejectsAutoFlushBytesAboveSfMaxBytesViaOptions(t *testing.T) {
 	err := sanitizeQwpConf(conf)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "auto_flush_bytes")
-	require.Contains(t, err.Error(), "sf_max_bytes")
+	require.Contains(t, err.Error(), "sf_max_segment_bytes")
 }
 
 // TestSfConfAcceptsDefaultedAutoFlushBytesOverSmallSegment is the
-// no-footgun case: lowering sf_max_bytes while leaving auto_flush_bytes
+// no-footgun case: lowering sf_max_segment_bytes while leaving auto_flush_bytes
 // at its 8 MiB default is NOT a user-written contradiction, so sanitize
 // must accept it — the runtime clamp lowers the effective trigger to
 // fit the smaller segment. Rejecting here would force users to hand-tune
 // auto_flush_bytes every time they shrink a segment.
 func TestSfConfAcceptsDefaultedAutoFlushBytesOverSmallSegment(t *testing.T) {
-	conf, err := confFromStr("ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_bytes=1048576;")
+	conf, err := confFromStr("ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_segment_bytes=1048576;")
 	require.NoError(t, err)
 	require.False(t, conf.autoFlushBytesSet, "auto_flush_bytes left at default")
 	require.Equal(t, qwpDefaultAutoFlushBytes, conf.autoFlushBytes)
-	require.Greater(t, int64(conf.autoFlushBytes), conf.sfMaxBytes,
+	require.Greater(t, int64(conf.autoFlushBytes), conf.sfMaxSegmentBytes,
 		"precondition: the defaulted trigger exceeds the chosen segment")
 
 	require.NoError(t, sanitizeQwpConf(conf),
 		"a defaulted trigger over a smaller segment is handled by the clamp, not rejected")
 }
 
-// TestSfConfAcceptsAutoFlushBytesBelowSfMaxBytes pins that a valid
+// TestSfConfAcceptsAutoFlushBytesBelowSfMaxSegmentBytes pins that a valid
 // explicit pairing (trigger at or below the segment) sanitizes cleanly.
-func TestSfConfAcceptsAutoFlushBytesBelowSfMaxBytes(t *testing.T) {
+func TestSfConfAcceptsAutoFlushBytesBelowSfMaxSegmentBytes(t *testing.T) {
 	conf, err := confFromStr(
-		"ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_bytes=4194304;auto_flush_bytes=2097152;")
+		"ws::addr=localhost:9000;sf_dir=/tmp/sf;sf_max_segment_bytes=4194304;auto_flush_bytes=2097152;")
 	require.NoError(t, err)
 	require.NoError(t, sanitizeQwpConf(conf))
 }
@@ -514,7 +514,7 @@ func TestSfOptionsWithReconnectPolicyMixedZeroOnlySetsPositive(t *testing.T) {
 func TestSanitizeQwpConfRejectsSfKeysWithoutSfDir(t *testing.T) {
 	cases := []func(c *lineSenderConfig){
 		func(c *lineSenderConfig) { c.senderId = "x" },
-		func(c *lineSenderConfig) { c.sfMaxBytes = 1 << 20 },
+		func(c *lineSenderConfig) { c.sfMaxSegmentBytes = 1 << 20 },
 		func(c *lineSenderConfig) { c.sfMaxTotalBytes = 1 << 30 },
 		func(c *lineSenderConfig) { c.sfDurability = "memory" },
 		func(c *lineSenderConfig) { c.sfAppendDeadlineMillis = 5000 },
@@ -537,7 +537,7 @@ func TestSanitizeQwpConfRejectsTotalLessThanSegment(t *testing.T) {
 	conf := newLineSenderConfig(qwpSenderType)
 	conf.address = "localhost:9000"
 	conf.sfDir = "/tmp/sf"
-	conf.sfMaxBytes = 1 << 20
+	conf.sfMaxSegmentBytes = 1 << 20
 	conf.sfMaxTotalBytes = 1 << 18
 	err := sanitizeQwpConf(conf)
 	require.Error(t, err)
@@ -557,7 +557,7 @@ func TestSfConfEndToEnd(t *testing.T) {
 		"ws::addr=" + addr,
 		"sf_dir=" + tmp,
 		"sender_id=test-slot",
-		"sf_max_bytes=4096",
+		"sf_max_segment_bytes=4096",
 		"sf_max_total_bytes=" + fmt.Sprintf("%d", int64(64*1024)),
 		"close_flush_timeout_millis=5000;",
 	}, ";")

--- a/qwp_sf_fallocate_unix_other.go
+++ b/qwp_sf_fallocate_unix_other.go
@@ -34,7 +34,7 @@ import "os"
 // extends the file to the new logical size, so the call returns
 // success as if the spec's sparse-fallback path were taken — blocks
 // remain sparse, SIGBUS risk per sf-client.md §6 applies. Operators
-// on these targets must size sf_max_bytes conservatively against
+// on these targets must size sf_max_segment_bytes conservatively against
 // free space.
 //
 // Add a platform-specific implementation here if QuestDB Go ever

--- a/qwp_transport.go
+++ b/qwp_transport.go
@@ -156,6 +156,10 @@ type qwpTransportOpts struct {
 	// pre-failover-spec behavior; sanitizeQwpConf seeds 15000 for
 	// QWP-configured callers.
 	authTimeoutMs int
+
+	// connectTimeoutMs, when > 0, bounds the TCP connect phase. Zero
+	// leaves the connect bounded by the OS.
+	connectTimeoutMs int
 }
 
 // qwpTransport wraps a WebSocket connection for sending QWP
@@ -349,6 +353,12 @@ func (t *qwpTransport) connect(ctx context.Context, url string, opts qwpTranspor
 	}
 	if opts.authTimeoutMs > 0 {
 		httpTransport.ResponseHeaderTimeout = time.Duration(opts.authTimeoutMs) * time.Millisecond
+	}
+	if opts.connectTimeoutMs > 0 {
+		dialer := &net.Dialer{
+			Timeout: time.Duration(opts.connectTimeoutMs) * time.Millisecond,
+		}
+		httpTransport.DialContext = dialer.DialContext
 	}
 
 	if t.dumpWriter != nil {

--- a/sender.go
+++ b/sender.go
@@ -365,7 +365,7 @@ type lineSenderConfig struct {
 	// autoFlushBytesSet records whether the user explicitly set
 	// auto_flush_bytes (vs. the seeded qwpDefaultAutoFlushBytes).
 	// sanitizeQwpConf uses it to reject only a user-written
-	// auto_flush_bytes > sf_max_bytes contradiction; a defaulted trigger
+	// auto_flush_bytes > sf_max_segment_bytes contradiction; a defaulted trigger
 	// over a smaller user-chosen segment is left for the runtime clamp.
 	autoFlushBytesSet bool
 
@@ -382,7 +382,7 @@ type lineSenderConfig struct {
 	// loop.
 	sfDir                         string
 	senderId                      string // empty -> "default" at construction
-	sfMaxBytes                    int64  // per-segment size (bytes); 0 -> 4 MiB
+	sfMaxSegmentBytes                    int64  // per-segment size (bytes); 0 -> 4 MiB
 	sfMaxTotalBytes               int64  // total cap (bytes); 0 -> 10 GiB
 	sfDurability                  string // empty / "memory" only; reserved future "flush" / "append"
 	sfAppendDeadlineMillis        int    // 0 -> 30000
@@ -568,14 +568,14 @@ func WithSenderId(id string) LineSenderOption {
 	}
 }
 
-// WithSfMaxBytes sets the per-segment cap (bytes) for the cursor
+// WithSfMaxSegmentBytes sets the per-segment cap (bytes) for the cursor
 // engine. Defaults to 4 MiB. Lower values rotate segments more
 // aggressively; higher values amortize the rotation overhead.
 //
 // Only available for the QWP sender.
-func WithSfMaxBytes(n int64) LineSenderOption {
+func WithSfMaxSegmentBytes(n int64) LineSenderOption {
 	return func(s *lineSenderConfig) {
-		s.sfMaxBytes = n
+		s.sfMaxSegmentBytes = n
 	}
 }
 
@@ -1295,8 +1295,8 @@ func sanitizeQwpConf(conf *lineSenderConfig) error {
 		if conf.senderId != "" {
 			return errors.New("sender_id requires sf_dir to be set")
 		}
-		if conf.sfMaxBytes != 0 || conf.sfMaxTotalBytes != 0 || conf.sfDurability != "" || conf.sfAppendDeadlineMillis != 0 {
-			return errors.New("sf_max_bytes / sf_max_total_bytes / sf_durability / sf_append_deadline_millis require sf_dir to be set")
+		if conf.sfMaxSegmentBytes != 0 || conf.sfMaxTotalBytes != 0 || conf.sfDurability != "" || conf.sfAppendDeadlineMillis != 0 {
+			return errors.New("sf_max_segment_bytes / sf_max_total_bytes / sf_durability / sf_append_deadline_millis require sf_dir to be set")
 		}
 		if conf.drainOrphans || conf.maxBackgroundDrainers != 0 {
 			return errors.New("drain_orphans / max_background_drainers require sf_dir to be set")
@@ -1326,31 +1326,31 @@ func sanitizeQwpConf(conf *lineSenderConfig) error {
 	// 0 is the use-default sentinel for both (resolved to
 	// qwpSfDefaultMaxBytes / qwpSfDefaultMaxTotalBytes at construction),
 	// so only a negative value is rejected here.
-	if conf.sfMaxBytes < 0 {
-		return fmt.Errorf("sf_max_bytes must be >= 0: %d", conf.sfMaxBytes)
+	if conf.sfMaxSegmentBytes < 0 {
+		return fmt.Errorf("sf_max_segment_bytes must be >= 0: %d", conf.sfMaxSegmentBytes)
 	}
 	if conf.sfMaxTotalBytes < 0 {
 		return fmt.Errorf("sf_max_total_bytes must be >= 0: %d", conf.sfMaxTotalBytes)
 	}
-	if conf.sfMaxBytes > 0 && conf.sfMaxTotalBytes > 0 && conf.sfMaxTotalBytes < conf.sfMaxBytes {
-		return fmt.Errorf("sf_max_total_bytes (%d) must be >= sf_max_bytes (%d)",
-			conf.sfMaxTotalBytes, conf.sfMaxBytes)
+	if conf.sfMaxSegmentBytes > 0 && conf.sfMaxTotalBytes > 0 && conf.sfMaxTotalBytes < conf.sfMaxSegmentBytes {
+		return fmt.Errorf("sf_max_total_bytes (%d) must be >= sf_max_segment_bytes (%d)",
+			conf.sfMaxTotalBytes, conf.sfMaxSegmentBytes)
 	}
 	// Reject an explicit auto_flush_bytes that exceeds an explicit
-	// sf_max_bytes. The byte trigger would let a batch grow until its
+	// sf_max_segment_bytes. The byte trigger would let a batch grow until its
 	// encoded frame can no longer fit a single segment, and such a frame
 	// can never be flushed — it is dropped at the flush boundary. Gated
 	// on autoFlushBytesSet so a *defaulted* 8 MiB trigger over a smaller
 	// user-chosen segment is left to the runtime clamp (which lowers the
 	// effective trigger to fit); only a user-written contradiction is a
-	// hard error. sf_max_bytes is the per-segment cap, so the frame must
+	// hard error. sf_max_segment_bytes is the per-segment cap, so the frame must
 	// actually fit in slightly less than this (header overhead), but the
 	// trigger clamp already keeps the encoded frame under the segment;
 	// this check just rejects the self-evidently impossible pairing up front.
-	if conf.autoFlushBytesSet && conf.sfMaxBytes > 0 && int64(conf.autoFlushBytes) > conf.sfMaxBytes {
+	if conf.autoFlushBytesSet && conf.sfMaxSegmentBytes > 0 && int64(conf.autoFlushBytes) > conf.sfMaxSegmentBytes {
 		return fmt.Errorf(
-			"auto_flush_bytes (%d) must not exceed sf_max_bytes (%d): a batch that fills the byte trigger could not fit in a single segment",
-			conf.autoFlushBytes, conf.sfMaxBytes)
+			"auto_flush_bytes (%d) must not exceed sf_max_segment_bytes (%d): a batch that fills the byte trigger could not fit in a single segment",
+			conf.autoFlushBytes, conf.sfMaxSegmentBytes)
 	}
 	if conf.maxBackgroundDrainers < 0 {
 		return fmt.Errorf("max_background_drainers must be >= 0: %d", conf.maxBackgroundDrainers)
@@ -1405,8 +1405,8 @@ func rejectQwpOnlyOptions(conf *lineSenderConfig) error {
 		name = "sf_dir"
 	case conf.senderId != "":
 		name = "sender_id"
-	case conf.sfMaxBytes != 0:
-		name = "sf_max_bytes"
+	case conf.sfMaxSegmentBytes != 0:
+		name = "sf_max_segment_bytes"
 	case conf.sfMaxTotalBytes != 0:
 		name = "sf_max_total_bytes"
 	case conf.sfDurability != "":

--- a/sender.go
+++ b/sender.go
@@ -372,8 +372,7 @@ type lineSenderConfig struct {
 	protocolVersion protocolVersion
 
 	// QWP-specific fields
-	dumpWriter      io.Writer // if set, record outgoing bytes (unexported)
-	gorillaDisabled bool      // false (default) = Gorilla timestamp encoding enabled
+	dumpWriter io.Writer // if set, record outgoing bytes (unexported)
 
 	// QWP store-and-forward (cursor) fields. Setting sfDir selects
 	// disk-backed segments: flushed batches are persisted to mmap'd
@@ -663,19 +662,6 @@ func WithCloseFlushTimeout(d time.Duration) LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.closeFlushTimeoutSet = true
 		s.closeFlushTimeoutMillis = int(d / time.Millisecond)
-	}
-}
-
-// WithGorilla enables or disables Gorilla delta-of-delta encoding for
-// timestamp columns. Defaults to enabled. When disabled, FLAG_GORILLA
-// is cleared on every message and timestamp columns are sent as raw
-// int64 little-endian values with no encoding-flag prefix.
-//
-// Mirrors QwpWebSocketSender.setGorillaEnabled in the Java client
-// (default true there as well). Only available for the QWP sender.
-func WithGorilla(enabled bool) LineSenderOption {
-	return func(s *lineSenderConfig) {
-		s.gorillaDisabled = !enabled
 	}
 }
 
@@ -1439,8 +1425,6 @@ func rejectQwpOnlyOptions(conf *lineSenderConfig) error {
 		name = "initial_connect_retry"
 	case conf.closeFlushTimeoutSet:
 		name = "close_flush_timeout_millis"
-	case conf.gorillaDisabled:
-		name = "gorilla"
 	case conf.dumpWriter != nil:
 		name = "QWP dump writer"
 	case conf.authTimeoutMs != 0:

--- a/sender.go
+++ b/sender.go
@@ -340,10 +340,11 @@ type lineSenderConfig struct {
 	// Non-QWP transports leave endpoints nil and continue using address
 	// directly — sanitizeHttp/sanitizeTcp reject comma-form addr at
 	// validation time since neither transport supports multi-host yet.
-	endpoints     []qwpEndpoint
-	authTimeoutMs int             // QWP-only; 0 -> 15000 (15s) at sanitize time
-	zone          string          // QWP-only; honoured on egress, inert on ingest (no zone routing)
-	target        QwpTargetFilter // QWP-only; zero value = QwpTargetAny
+	endpoints        []qwpEndpoint
+	authTimeoutMs    int             // QWP-only; 0 -> 15000 (15s) at sanitize time
+	connectTimeoutMs int             // QWP-only; 0 leaves TCP connect bounded by the OS
+	zone             string          // QWP-only; honoured on egress, inert on ingest (no zone routing)
+	target           QwpTargetFilter // QWP-only; zero value = QwpTargetAny
 
 	// Retry/timeout-related fields
 	retryTimeout   time.Duration
@@ -1269,6 +1270,9 @@ func sanitizeQwpConf(conf *lineSenderConfig) error {
 	if conf.authTimeoutMs <= 0 {
 		conf.authTimeoutMs = 15_000
 	}
+	if conf.connectTimeoutMs < 0 {
+		return errors.New("connect_timeout must be >= 0")
+	}
 	// Implicit promotion of initial_connect_retry. When the user tuned
 	// any reconnect_* knob but did not pick an initial-connect mode,
 	// promote to sync — the reconnect budget they wrote should also
@@ -1429,6 +1433,8 @@ func rejectQwpOnlyOptions(conf *lineSenderConfig) error {
 		name = "QWP dump writer"
 	case conf.authTimeoutMs != 0:
 		name = "auth_timeout_ms"
+	case conf.connectTimeoutMs != 0:
+		name = "connect_timeout"
 	case conf.zone != "":
 		name = "zone"
 	case conf.target != qwpTargetAny:
@@ -1444,6 +1450,7 @@ func newQwpLineSenderFromConf(ctx context.Context, conf *lineSenderConfig) (Line
 		tlsInsecureSkipVerify: conf.tlsMode == tlsInsecureSkipVerify,
 		endpointPath:          qwpWritePath,
 		authTimeoutMs:         conf.authTimeoutMs,
+		connectTimeoutMs:      conf.connectTimeoutMs,
 		// QWP has a single protocol version; advertise it.
 		// serverInfoTimeout stays zero: the ingest endpoint sends no
 		// SERVER_INFO frame and the client never expects one — it sends

--- a/sender.go
+++ b/sender.go
@@ -372,7 +372,6 @@ type lineSenderConfig struct {
 	protocolVersion protocolVersion
 
 	// QWP-specific fields
-	inFlightWindow  int       // retained for config compatibility; a no-op in the cursor architecture (see WithInFlightWindow). Seeded to qwpDefaultInFlightWindow by newLineSenderConfig
 	dumpWriter      io.Writer // if set, record outgoing bytes (unexported)
 	gorillaDisabled bool      // false (default) = Gorilla timestamp encoding enabled
 
@@ -436,24 +435,6 @@ func WithTcp() LineSenderOption {
 func WithQwp() LineSenderOption {
 	return func(s *lineSenderConfig) {
 		s.senderType = qwpSenderType
-	}
-}
-
-// WithInFlightWindow is retained for backward compatibility but is a
-// no-op. In the QWP cursor architecture, backpressure is governed by
-// the engine's segment ring and the append deadline, not by a fixed
-// in-flight batch count. Flush never waits for the server ACK, so
-// there is no synchronous mode to opt into. Connect strings carrying
-// in_flight_window still parse; the value is ignored.
-//
-// Only available for the QWP sender.
-//
-// Deprecated: the in-flight window has no effect and there is no
-// replacement — backpressure is automatic. To confirm server ACKs,
-// pair FlushAndGetSequence with AwaitAckedFsn.
-func WithInFlightWindow(window int) LineSenderOption {
-	return func(s *lineSenderConfig) {
-		s.inFlightWindow = window
 	}
 }
 
@@ -1161,7 +1142,6 @@ func newLineSenderConfig(t senderType) *lineSenderConfig {
 			autoFlushRows:     qwpDefaultAutoFlushRows,
 			autoFlushInterval: qwpDefaultAutoFlushInterval,
 			autoFlushBytes:    qwpDefaultAutoFlushBytes,
-			inFlightWindow:    qwpDefaultInFlightWindow,
 			initBufSize:       defaultInitBufferSize,
 			maxBufSize:        defaultMaxBufferSize,
 			fileNameLimit:     defaultFileNameLimit,
@@ -1283,9 +1263,6 @@ func sanitizeQwpConf(conf *lineSenderConfig) error {
 	// QWP auth: either Basic (user+pass) or Bearer (token), not both.
 	if (conf.httpUser != "" || conf.httpPass != "") && conf.httpToken != "" {
 		return errors.New("both basic and token authentication cannot be used")
-	}
-	if conf.inFlightWindow < 0 {
-		return fmt.Errorf("in-flight window is negative: %d", conf.inFlightWindow)
 	}
 	if conf.protocolVersion != protocolVersionUnset {
 		return errors.New("protocol_version setting is not available in the QWP client")
@@ -1466,8 +1443,6 @@ func rejectQwpOnlyOptions(conf *lineSenderConfig) error {
 		name = "gorilla"
 	case conf.dumpWriter != nil:
 		name = "QWP dump writer"
-	case conf.inFlightWindow != 0:
-		name = "in_flight_window"
 	case conf.authTimeoutMs != 0:
 		name = "auth_timeout_ms"
 	case conf.zone != "":

--- a/sender.go
+++ b/sender.go
@@ -691,6 +691,18 @@ func WithAuthTimeout(d time.Duration) LineSenderOption {
 	}
 }
 
+// WithConnectTimeout bounds each TCP connect attempt made by the QWP
+// transport. Zero leaves the connect bounded by the operating system;
+// negative durations are rejected at construction. Equivalent to the
+// connect-string connect_timeout key.
+//
+// Only available for the QWP sender.
+func WithConnectTimeout(d time.Duration) LineSenderOption {
+	return func(s *lineSenderConfig) {
+		s.connectTimeoutMs = int(d / time.Millisecond)
+	}
+}
+
 // WithZone sets the failover zone hint used for endpoint locality.
 // It is silently stored but inert on the ingestion path, which is
 // zone-blind — it never receives SERVER_INFO. The egress (query) path

--- a/sender.go
+++ b/sender.go
@@ -383,7 +383,7 @@ type lineSenderConfig struct {
 	// loop.
 	sfDir                         string
 	senderId                      string // empty -> "default" at construction
-	sfMaxSegmentBytes                    int64  // per-segment size (bytes); 0 -> 4 MiB
+	sfMaxSegmentBytes             int64  // per-segment size (bytes); 0 -> 4 MiB
 	sfMaxTotalBytes               int64  // total cap (bytes); 0 -> 10 GiB
 	sfDurability                  string // empty / "memory" only; reserved future "flush" / "append"
 	sfAppendDeadlineMillis        int    // 0 -> 30000

--- a/sender.go
+++ b/sender.go
@@ -699,6 +699,13 @@ func WithAuthTimeout(d time.Duration) LineSenderOption {
 // Only available for the QWP sender.
 func WithConnectTimeout(d time.Duration) LineSenderOption {
 	return func(s *lineSenderConfig) {
+		if d < 0 {
+			// A sub-millisecond negative truncates to 0 and would read
+			// as the zero (OS-default) case, so map every negative to a
+			// value the construction-time check rejects.
+			s.connectTimeoutMs = -1
+			return
+		}
 		s.connectTimeoutMs = int(d / time.Millisecond)
 	}
 }


### PR DESCRIPTION

Consolidates the QWP (`ws::` / `wss::`) connect-string configuration vocabulary. A single connect string has to drive both the ingress `LineSender` and the egress `QwpQueryClient`, so this PR settles which keys each side accepts, drops keys that no longer carry meaning, tightens per-transport validation, and renames one key for clarity. Almost every change is confined to the QWP transport; the sole cross-transport change is the `user` / `pass` credential aliasing, which resolves in the shared connect-string tokenizer and so also affects the legacy ILP `http(s)::` / `tcp(s)::` schemas (detailed under *One connect string for ingress and egress* below).

### Removed QWP options

- **`auth` / `WithQwpQueryAuth`** — the query client no longer accepts a pre-formed `Authorization` header value. Credentials are given as the structured `username` / `password` or `token` keys, from which the client synthesizes the Basic or Bearer header downstream. Mirrors the Java client change of the same name.
- **`in_flight_window` / `WithInFlightWindow`** — a dead no-op. The value never reached the sender: the cursor architecture governs backpressure through the segment ring and the append deadline, and `Flush` never waits for the ACK. The key now falls through to the generic parser and is rejected as an unsupported option.
- **`gorilla` / `WithGorilla`** — the encoder now always sets `FLAG_GORILLA` and unconditionally applies Gorilla delta-of-delta timestamp encoding on ingress, keeping the per-column fallback to uncompressed when the delta-of-deltas overflow int32. The egress decoder is unchanged — it still reads the server's `FLAG_GORILLA` bit and handles both encoded and raw timestamps.

### One connect string for ingress and egress

- The **ingress** parser now accepts the egress-only keys (`path`, `client_id`, `server_info_timeout_ms`, `replay_exec`) and the Java-parity ingress keys the doc Key index omits (`transaction`, `connection_listener_inbox_capacity`) as validated no-ops or equivalents.
- The **egress** parser silently ignores the ingress-only keys.

Either side parses the shared string without rejecting the other side's keys.

**`user` / `pass` are shared aliases, not QWP-scoped.** They canonicalize to `username` / `password` in the shared connect-string tokenizer (`canonicalConfigKey`), ahead of any per-schema handling, so they resolve on **every** transport, not just QWP. On QWP and `http(s)::` they map to the Basic-auth user/password; on `tcp(s)::`, `user` maps to the key id exactly as `username` always has (`pass` stays rejected there, as `password` always was). This is a deliberate widening: those spellings were previously rejected as unsupported options on the legacy ILP transports. No existing valid config changes meaning — the mapping matches how `username` / `password` already behaved on each transport.

### Non-QWP keys rejected on the QWP path

- Legacy ILP HTTP keys — `protocol_version` (including `=auto`, which previously slipped through because it leaves the field unset), `request_timeout`, `request_min_throughput`, `retry_timeout` — are rejected on QWP while `http::` / `tcp::` still accept them. The protocol version is negotiated at the WebSocket upgrade.
- ECDSA `token_x` / `token_y` are rejected on QWP, restoring ingress/egress symmetry (they remain ignored on the legacy ILP transports, which don't need the public key).
- The UDP-only keys `max_datagram_size` / `multicast_ttl` are rejected on QWP; this client has no UDP transport.

This matches the egress `QwpQueryClient` and the Java, Rust, and .NET clients.

### Rename: `sf_max_bytes` → `sf_max_segment_bytes`

The key caps a single store-and-forward segment, and the new name says so; it also pairs cleanly with `sf_max_total_bytes`. The public option follows: `WithSfMaxBytes` is now `WithSfMaxSegmentBytes`. Internal identifiers, error messages, tests, the README, and the SF example rename in step, so the repo greps zero for the old spelling in any case variant.

### Cross-repo parity

Several changes track the Java client (`Sender.java`): the `sf_max_bytes` rename (matching questdb/java-questdb-client#70), the `auth` removal, and the shared ingress/egress key vocabulary. A connect string that works on the Java QWP client is meant to work here.

### API impact

This is almost entirely confined to the QWP transport, which is still being stabilized ahead of its first stable release — the full transport (store-and-forward cursor engine, query client, typed errors, failover) landed in #62, after v4.2.0. The lone exception is the shared-tokenizer `user` / `pass` aliasing described above, which now also parses on `http(s)::` / `tcp(s)::` (spellings previously rejected as unsupported options); it only widens what parses and leaves every existing valid config unchanged. `sf_max_bytes` / `WithSfMaxBytes` and `WithQwpQueryAuth` are part of that unreleased surface. `WithGorilla` and `WithInFlightWindow` shipped with the QWP ingress in v4.2.0, so their removal is a breaking change (flagged under Breaking Changes below).

### Verification

`go build ./...` and `go vet ./...` are green locally; the Docker integration suite is CI's to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed `sf_max_bytes` → `sf_max_segment_bytes` (and `WithSfMaxBytes` → `WithSfMaxSegmentBytes`).
  * Removed `WithInFlightWindow` and `WithGorilla`; QWP no longer accepts `in_flight_window`/`gorilla` connect-string knobs.
  * Removed `WithQwpQueryAuth`; query connect strings no longer accept the legacy `auth` key.
* **New Features**
  * Added `connect_timeout` for QWP connect strings.
  * Added `WithQwpQueryConnectTimeout` for QWP query clients.
* **Bug Fixes**
  * Stricter, transport-aware QWP connect-string validation and clearer option rejection.
* **Documentation**
  * Updated QWP SF docs, parity notes, and examples to use `sf_max_segment_bytes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

