### PR TITLE
fix(qwp): recycle the connection after a server NACK

### DIFF
--- a/qwp_error_resilience_test.go
+++ b/qwp_error_resilience_test.go
@@ -1046,41 +1046,45 @@ func TestErrorApiResilience_ServerRestartReplaysCorrectly(t *testing.T) {
 // within a bounded time (the dispatcher's drain timeout caps the
 // wait). Without this cap, a malicious or buggy handler could stall
 // shutdown indefinitely. The cap is currently 100 ms; the test
-// asserts < 1 s for headroom.
+// asserts < 750 ms for headroom.
 func TestErrorApiResilience_DispatcherDrainTimeoutCap(t *testing.T) {
+	// rejectFromConn: 1 → every connection NACKs its first frame.
+	// Each Drop rejection recycles the connection (the error frame
+	// breaks its ordered pipeline), so queueing N errors takes N
+	// connections.
 	srv := newQwpSfTestServer(t, qwpSfTestServerOpts{
-		rejectStatus:       QwpStatusSchemaMismatch,
-		rejectFirstNFrames: 100,
+		rejectStatus:   QwpStatusSchemaMismatch,
+		rejectFromConn: 1,
 	})
 	defer srv.Close()
 
 	s, _, loop, _ := newCursorSenderForTest(t, srv, 0)
 
-	// Slow handler: each call takes 50 ms. With 100 queued items,
-	// processing them all would take 5 s; the drain timeout (100 ms)
-	// must cap that.
+	// Slow handler: each call takes 50 ms. With 25 queued items,
+	// processing them all would take 1.25 s; the drain timeout
+	// (100 ms) must cap that.
 	loop.sendLoopSetErrorHandler(func(e *SenderError) {
 		time.Sleep(50 * time.Millisecond)
 	}, 256) // generous capacity so most drops queue rather than getting dropped
 
-	// Drive 100 drops as fast as possible.
-	for i := 0; i < 100; i++ {
+	// Drive 25 drops as fast as possible.
+	for i := 0; i < 25; i++ {
 		require.NoError(t, s.Table("t").Int64Column("v", int64(i)).AtNow(context.Background()))
 		require.NoError(t, s.Flush(context.Background()))
 	}
 	require.Eventually(t, func() bool {
-		return s.TotalServerErrors() >= 100
-	}, 5*time.Second, 1*time.Millisecond)
+		return s.TotalServerErrors() >= 25
+	}, 10*time.Second, 1*time.Millisecond)
 
 	// Now close — the drain timeout must fire before the slow
-	// handler chews through all 100 queued items.
+	// handler chews through all 25 queued items.
 	start := time.Now()
 	_ = s.Close(context.Background())
 	elapsed := time.Since(start)
 
-	// Allow generous headroom but assert we're not blocked for the
-	// full 5 s the slow handler would otherwise need.
-	assert.Less(t, elapsed, 2*time.Second,
+	// Allow generous headroom but assert well under the 1.25 s the
+	// slow handler would otherwise need.
+	assert.Less(t, elapsed, 750*time.Millisecond,
 		"close should not wait for a slow handler past the drain timeout")
 }
 
@@ -1089,16 +1093,22 @@ func TestErrorApiResilience_DispatcherDrainTimeoutCap(t *testing.T) {
 // =============================================================================
 
 // TestErrorApiResilience_DropStreakThenHalt models a realistic
-// scenario: many rows fail with WriteError (Drop policy), the loop
-// keeps draining, then a row hits ParseError (Halt policy) and the
-// loop latches. The Drop counter and Halt latch should be
+// scenario: several rows fail with WriteError (Drop policy) — each
+// drop recycling the connection and replaying the tail — then a row
+// hits ParseError (Halt policy) and the loop stops with a terminal
+// error. The Drop counter and the terminal error should be
 // independent; the FSN on the Halt should be > the FSNs of the
 // Drops.
 func TestErrorApiResilience_DropStreakThenHalt(t *testing.T) {
-	// Custom server: WriteError for first 3 frames, ParseError on
-	// frame 4. Switch by adding a custom handler — the existing
-	// fixture only supports one rejectStatus per server.
-	var nFrames atomic.Int32
+	// Custom server: WriteError for the first 3 rejected frames,
+	// ParseError on the 4th. One error response per connection —
+	// the error frame breaks the connection's ordered pipeline, so
+	// the server drains further frames without responding (the
+	// client recycles and replays them on a fresh connection),
+	// matching the real server's unresolved-sequence refusal. The
+	// custom handler exists because the fixture only supports one
+	// rejectStatus per server.
+	var nRejects atomic.Int32
 	srv := &qwpSfTestServer{kill: make(chan struct{})}
 	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(qwpHeaderVersion, "1")
@@ -1107,23 +1117,29 @@ func TestErrorApiResilience_DropStreakThenHalt(t *testing.T) {
 			return
 		}
 		defer conn.CloseNow()
-		var localSeq int64
+		responded := false
 		for {
 			_, _, err := conn.Read(context.Background())
 			if err != nil {
 				return
 			}
-			n := nFrames.Add(1)
 			srv.totalFramesReceived.Add(1)
+			if responded {
+				// Pipeline broken by the error frame: refuse silently.
+				continue
+			}
+			n := nRejects.Add(1)
 			var status QwpStatusCode
 			if n <= 3 {
 				status = QwpStatusWriteError // Drop
 			} else {
 				status = QwpStatusParseError // Halt
 			}
+			// Each connection's first frame is the replay head, so the
+			// rejection always names wire seq 0.
 			_ = conn.Write(context.Background(), websocket.MessageBinary,
-				buildAckError(status, localSeq, "rejected"))
-			localSeq++
+				buildAckError(status, 0, "rejected"))
+			responded = true
 		}
 	}))
 	defer srv.Close()

--- a/qwp_error_resilience_test.go
+++ b/qwp_error_resilience_test.go
@@ -457,10 +457,12 @@ func TestErrorApiResilience_ReconnectThenHaltFsnCorrelation(t *testing.T) {
 // to 1 (both drops counted as "resolved by server") and no terminal
 // error is latched.
 func TestErrorApiResilience_DropAcrossReconnect(t *testing.T) {
-	// Connection 1: drop frame 0 (rejectFirstNFrames=1), then close
-	// after reading frame 1 (closeAfterFrames=2). One ACK delivered,
-	// so the silent-drop guard does not fire and reconnect kicks in.
-	// Connection 2: rejectFromConn=2 means reject all frames on conn ≥ 2.
+	// Connection 1: NACK frame 0 (rejectFirstNFrames=1); the drop
+	// recycles the connection. Connection 2+: rejectFromConn=2 rejects
+	// every frame, so the replayed frame 1 is dropped there too.
+	// closeAfterFrames=2 is a backstop: if frame 1 races onto conn 1
+	// before the recycle tears it down, the server closes the
+	// connection and frame 1 replays on conn 2 all the same.
 	srv := newQwpSfTestServer(t, qwpSfTestServerOpts{
 		rejectStatus:       QwpStatusSchemaMismatch,
 		rejectFirstNFrames: 1,
@@ -478,8 +480,8 @@ func TestErrorApiResilience_DropAcrossReconnect(t *testing.T) {
 	require.Eventually(t, func() bool { return engine.engineAckedFsn() >= 0 },
 		2*time.Second, 1*time.Millisecond, "frame 0 must be drop-acked on conn 1")
 
-	// Frame 1: conn 1 reads it then closes (no ACK). The loop reconnects
-	// and replays frame 1 on conn 2, which drops it (ackedFsn → 1).
+	// Frame 1: goes out on conn 2 (the drop on conn 1 recycled the
+	// connection), which rejects it too → dropped, ackedFsn → 1.
 	require.NoError(t, s.Table("t").Int64Column("v", 1).AtNow(context.Background()))
 	require.NoError(t, s.Flush(context.Background()))
 
@@ -896,7 +898,7 @@ func runHaltStressOnce(t *testing.T, iter, goroutines int) {
 func TestErrorApiResilience_DispatcherSwapMidFlight(t *testing.T) {
 	srv := newQwpSfTestServer(t, qwpSfTestServerOpts{
 		rejectStatus:       QwpStatusSchemaMismatch,
-		rejectFirstNFrames: 50, // 50 drops on conn 1
+		rejectFirstNFrames: 50, // 50 drops, one per connection
 	})
 	defer srv.Close()
 

--- a/qwp_ingress_oracle_fuzz_test.go
+++ b/qwp_ingress_oracle_fuzz_test.go
@@ -1017,11 +1017,12 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 //
 // A poisoned chunk carries one row whose dec256 unscaled value is 2^192
 // (~6.3e57, 58 digits) — well past DECIMAL(50,6)'s 10^50 cap. The
-// server returns CategoryWriteError, whose spec-default policy is
-// DROP_AND_CONTINUE (qwp_sf_classify.go), so the producer keeps going
-// and the rejection surfaces only via the async handler. No server
-// bounce on purpose — the failure mode must be unambiguously the
-// per-frame rejection, not a transport blip.
+// server rejects it as SCHEMA_MISMATCH (a deterministic data-shape
+// rejection), whose spec-default policy is DROP_AND_CONTINUE
+// (qwp_sf_classify.go), so the producer keeps going and the rejection
+// surfaces only via the async handler. No server bounce on purpose —
+// the failure mode must be unambiguously the per-frame rejection, not
+// a transport blip.
 //
 // Faithful-port divergences (cf. the file header and the bounce port):
 //
@@ -1041,7 +1042,7 @@ func TestQwpFuzzIngressOracleMultiSenderBounce(t *testing.T) {
 //     bound 3x catches "handler fires N times per chunk" regressions
 //     the Java port doesn't guard.
 //   - Goes beyond the Java port: also captures one delivered
-//     *SenderError and asserts Category == CategoryWriteError and
+//     *SenderError and asserts Category == CategorySchemaMismatch and
 //     AppliedPolicy == PolicyDropAndContinue, so a misclassification
 //     (wrong status byte → wrong category) or a policy-resolution
 //     regression cannot pass silently behind the call-count alone.
@@ -1233,13 +1234,14 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 		t.Fatalf("error handler fired %d times, expected <= %d (3x poisoned chunks)",
 			got, upper)
 	}
-	// Inspect at least one delivered payload: misclassifying the
-	// dec256 overflow into a non-WriteError category, or resolving
-	// its policy to anything other than DROP_AND_CONTINUE, must
-	// fail the test even though the call count alone would still
-	// match. (A HALT resolution would also surface as a Flush error
-	// above, but we assert the policy here explicitly so the
-	// contract is self-documenting.)
+	// Inspect at least one delivered payload: the server reports the
+	// dec256 overflow as SCHEMA_MISMATCH (a deterministic data-shape
+	// rejection); misclassifying it, or resolving its policy to
+	// anything other than DROP_AND_CONTINUE, must fail the test even
+	// though the call count alone would still match. (A HALT
+	// resolution would also surface as a Flush error above, but we
+	// assert the policy here explicitly so the contract is
+	// self-documenting.)
 	if totalPoisonedChunks > 0 {
 		firstErrMu.Lock()
 		se := firstErr
@@ -1247,9 +1249,9 @@ func TestQwpFuzzIngressOraclePoisonErrorHandler(t *testing.T) {
 		if se == nil {
 			t.Fatalf("error handler fired %d times but no *SenderError captured", got)
 		}
-		if se.Category != CategoryWriteError {
+		if se.Category != CategorySchemaMismatch {
 			t.Fatalf("error handler: wrong category: got %s (status=0x%02X), "+
-				"expected WRITE_ERROR; msg=%q",
+				"expected SCHEMA_MISMATCH; msg=%q",
 				se.Category, byte(se.ServerStatusByte), se.ServerMessage)
 		}
 		if se.AppliedPolicy != PolicyDropAndContinue {

--- a/qwp_sf_send_loop.go
+++ b/qwp_sf_send_loop.go
@@ -1152,9 +1152,19 @@ func (l *qwpSfSendLoop) receiverLoop(ctx context.Context) error {
 			// status byte, resolve the policy, surface a typed
 			// SenderError. Halt latches and exits the receiver loop;
 			// DropAndContinue advances ackedFsn past the rejected
-			// span and keeps draining (the bytes on disk are the
-			// bytes the server rejected — reconnect/replay cannot
-			// fix them; only dropping moves us past them).
+			// span (the bytes on disk are the bytes the server
+			// rejected — replaying them cannot help; only dropping
+			// moves us past them) and then recycles the wire. The
+			// recycle is required for progress: after emitting an
+			// error frame the server silently refuses every further
+			// frame on the connection (its ordered pipeline is
+			// broken — committing a later frame would advance data
+			// past the gap its ack watermark stopped at), so
+			// draining here would wait forever on acks that cannot
+			// arrive. The reconnect path replays the refused tail
+			// from the advanced watermark on a fresh connection.
+			// Mirrors the Java client's post-rejection connection
+			// recycle.
 			//
 			// Sanity clamp: do not trust a rejection wireSeq beyond the
 			// frames whose sendMessage has fully returned. Without this
@@ -1185,6 +1195,9 @@ func (l *qwpSfSendLoop) receiverLoop(ctx context.Context) error {
 				// the watermark advance entirely; there is nothing
 				// on this connection to drop. Still surface the
 				// typed error so HALT latches and the handler fires.
+				// Non-halt policies recycle the wire: the error frame
+				// broke the connection's ordered pipeline, so any
+				// frame sent on it now would be silently refused.
 				// Mirrors handlePreSendRejection in the Java client.
 				from := l.engine.engineAckedFsn() + 1
 				to := l.engine.enginePublishedFsn()
@@ -1208,7 +1221,9 @@ func (l *qwpSfSendLoop) receiverLoop(ctx context.Context) error {
 					return se
 				}
 				l.dispatcher.Load().offer(se)
-				continue
+				return fmt.Errorf(
+					"qwp/sf: pre-send server rejection (%v, status=0x%x): recycling connection",
+					cat, int(status))
 			}
 			cappedSeq := seq
 			if cappedSeq > highestSent {
@@ -1241,10 +1256,21 @@ func (l *qwpSfSendLoop) receiverLoop(ctx context.Context) error {
 			// segment manager will trim the now-acked range on its
 			// next maintenance pass. Bump totalAcks for parity with
 			// the success path so producer-visible counters reflect
-			// "the server has resolved this batch".
+			// "the server has resolved this batch" — the bump also
+			// keeps the silent-connection terminal heuristic in run()
+			// from counting rejection recycles as ACK-less strikes.
 			l.engine.engineAcknowledge(fsn)
 			l.totalAcks.Add(1)
-			continue
+			// Recycle the wire (see the classify comment above): the
+			// server refuses the pipelined tail after an error frame,
+			// so the reconnect path must replay it — starting past
+			// the just-dropped frame — on a fresh connection. A plain
+			// error (no terminal error recorded) routes run() to
+			// connectWithBackoff, the same paced path a transport
+			// failure takes.
+			return fmt.Errorf(
+				"qwp/sf: server rejected wire seq %d (%v, status=0x%x): recycling connection to replay past the dropped frame",
+				seq, cat, int(status))
 		}
 		// Record the server's cumulative ACK sequence, then reconcile it
 		// against highestFullySent. applyAckWatermark caps the advance at

--- a/qwp_sf_send_loop.go
+++ b/qwp_sf_send_loop.go
@@ -1266,8 +1266,10 @@ func (l *qwpSfSendLoop) receiverLoop(ctx context.Context) error {
 			// so the reconnect path must replay it — starting past
 			// the just-dropped frame — on a fresh connection. A plain
 			// error (no terminal error recorded) routes run() to
-			// connectWithBackoff, the same paced path a transport
-			// failure takes.
+			// connectWithBackoff, the same reconnect path a transport
+			// failure takes; backoff pacing engages only if the dial
+			// itself fails, so a healthy server is redialed
+			// immediately.
 			return fmt.Errorf(
 				"qwp/sf: server rejected wire seq %d (%v, status=0x%x): recycling connection to replay past the dropped frame",
 				seq, cat, int(status))

--- a/qwp_sf_send_loop_test.go
+++ b/qwp_sf_send_loop_test.go
@@ -76,10 +76,13 @@ type qwpSfTestServerOpts struct {
 	// the missing ACKs. Used by close-drain-timeout tests.
 	silentAcks bool
 	// rejectFirstNFrames > 0, in combination with rejectStatus,
-	// causes only the first N frames on the very first connection to
-	// receive an error ACK; everything after gets OK. Used to test
-	// DROP-and-continue semantics where the loop must keep draining
-	// past the rejected span.
+	// caps rejection at N error ACKs total, at most one per
+	// connection: an error frame breaks the connection's ordered
+	// pipeline, so the frames behind it are refused silently (read,
+	// never answered) until the client recycles the connection; once
+	// N rejections have been issued, frames get OK. Used to test
+	// DROP-and-continue semantics where the loop drops the rejected
+	// span and replays the tail on a fresh connection.
 	rejectFirstNFrames int
 	// rejectFromConn > 0, in combination with rejectStatus, causes
 	// only connections with myConnID >= rejectFromConn to issue
@@ -120,6 +123,9 @@ type qwpSfTestServer struct {
 	*httptest.Server
 	totalFramesReceived atomic.Int64
 	connCount           atomic.Int64
+	// rejectsIssued counts error ACKs issued under the
+	// rejectFirstNFrames cap, across all connections.
+	rejectsIssued atomic.Int64
 	// kill is closed by tests that want to actively tear down every
 	// in-flight WS connection. httptest.Server.Close (and even
 	// CloseClientConnections) do not force-close hijacked
@@ -206,6 +212,10 @@ func qwpSfTestServerHandler(t *testing.T, s *qwpSfTestServer, opts qwpSfTestServ
 		myConnID := s.connCount.Add(1)
 		var localSeq int64
 		var localFramesReceived int
+		// Set once this connection has issued its rejectFirstNFrames
+		// error ACK; the rest of the connection's frames are then
+		// refused silently (broken ordered pipeline).
+		errorSentOnConn := false
 		if opts.unsolicitedRejectAtConnect != 0 {
 			// Send a single rejection ACK with sequence 0 BEFORE the
 			// client has had a chance to send anything. The receiver
@@ -271,14 +281,16 @@ func qwpSfTestServerHandler(t *testing.T, s *qwpSfTestServer, opts qwpSfTestServ
 			if opts.rejectStatus != 0 {
 				// Default behavior with no gating: reject every frame.
 				rejectThisFrame := true
-				// rejectFirstNFrames gates rejection to the first N
-				// frames of conn 1 (and silently passes on conn 2+).
+				// rejectFirstNFrames caps rejection at N error ACKs
+				// total, one per connection; after a connection's
+				// error ACK its pipelined tail is refused silently
+				// (the client recycles and replays it on a fresh
+				// connection).
 				if opts.rejectFirstNFrames > 0 {
-					if myConnID == 1 {
-						rejectThisFrame = localFramesReceived <= opts.rejectFirstNFrames
-					} else {
-						rejectThisFrame = false
+					if errorSentOnConn {
+						continue
 					}
+					rejectThisFrame = s.rejectsIssued.Load() < int64(opts.rejectFirstNFrames)
 				}
 				// rejectFromConn additively re-enables rejection on
 				// conn N+. Combined with rejectFirstNFrames, this models
@@ -291,6 +303,10 @@ func qwpSfTestServerHandler(t *testing.T, s *qwpSfTestServer, opts qwpSfTestServ
 					}
 				}
 				if rejectThisFrame {
+					if opts.rejectFirstNFrames > 0 {
+						s.rejectsIssued.Add(1)
+						errorSentOnConn = true
+					}
 					_ = conn.Write(context.Background(), websocket.MessageBinary,
 						buildAckError(opts.rejectStatus, localSeq, "rejected"))
 					localSeq++
@@ -1402,7 +1418,10 @@ func testQwpSfSendLoopDropAndContinue(t *testing.T, sfDir string) {
 	loop.sendLoopStart()
 	defer func() { _ = loop.sendLoopClose() }()
 
-	// First frame is rejected → dropped. Frames 1 and 2 (0-indexed) are OK.
+	// First frame is rejected → dropped, and the rejection breaks the
+	// connection's ordered pipeline, so the loop recycles the wire and
+	// replays frames 1 and 2 (0-indexed) on a fresh connection, where
+	// they get OK ACKs.
 	for i := 0; i < 3; i++ {
 		_, err := engine.engineAppendBlocking(context.Background(),
 			[]byte(fmt.Sprintf("f%d", i)))
@@ -1412,9 +1431,11 @@ func testQwpSfSendLoopDropAndContinue(t *testing.T, sfDir string) {
 		return engine.engineAckedFsn() >= 2
 	}, 5*time.Second, 1*time.Millisecond, "ackedFsn did not advance past Drop")
 
-	// No terminal error; reconnect did not trigger.
+	// No terminal error; the drop recycled the connection instead.
 	require.NoError(t, loop.sendLoopCheckError())
-	require.Equal(t, int64(0), loop.sendLoopTotalReconnects())
+	require.GreaterOrEqual(t, loop.sendLoopTotalReconnects(), int64(1),
+		"a Drop rejection must recycle the connection: the server refuses "+
+			"every frame after an error frame, so the tail replays on a fresh one")
 	// Dispatcher saw exactly one Drop-category SenderError.
 	require.GreaterOrEqual(t, dispatched.Load(), int64(1))
 	// Counter bumped on the Drop path.


### PR DESCRIPTION
Fixes the ingestion stall behind the `qwp-fuzz` failures on #66: `TestQwpFuzzIngressOraclePoisonErrorHandler` timed out with only a fraction of the clean rows landing (e.g. 30/790, then 0/235 on rerun with a different seed), and a `workflow_dispatch` baseline on untouched `main` failed identically — the stall is pre-existing and independent of the rename PR.

**Root cause.** After the server rejects a frame it silently refuses every further frame on that connection (`QwpIngressUpgradeProcessor.handleBinaryMessage`: an unresolved sequence means "the client replays it from its acked watermark on a fresh connection"). The go client's `PolicyDropAndContinue` path advanced the watermark past the rejected frame and then kept draining on the same connection — waiting forever on acks the server would never send. Ingestion stalled without erroring after the first NACK. The server log shows the signature: one `rejected [status=SCHEMA_MISMATCH...]` per connection, then silence with the connection still open.

**Fix.** The receiver still advances the watermark past the dropped frame, then returns a plain error so `run()` recycles the wire through the normal reconnect path (`connectWithBackoff` → `swapClient`), replaying the refused tail on a fresh connection starting past the drop. Pre-send rejections with non-halt policies recycle the same way. This mirrors the Java client's post-rejection recycle (`handleServerRejection`: "recycling connection, will replay from fsn ..."), which is why the server's own Java-client e2e never hit this.

**Tests.**
- The mock server's `rejectFirstNFrames` now models the server contract: N error ACKs total, at most one per connection, with the connection's pipelined tail refused silently.
- `TestQwpSfSendLoopDropAndContinue` asserts the recycle; `DropStreakThenHalt` got a pipeline-faithful custom mock; `DispatcherDrainTimeoutCap` uses per-connection rejections with a tighter close bound.
- The poison test's dec256-overflow expectation follows the server's `SCHEMA_MISMATCH` classification of deterministic data-shape rejections (`WRITE_ERROR` was stale; both resolve to the Drop policy).

**Validation.** Local run of the CI race job's exact filter (`go test -race -run '^TestQwp(Integration|FuzzIngress)'`) against a freshly built server master jar: 73/73 pass, no data races. The previously stalling seed now finishes in ~4s: all 235 clean rows land and `handlerCalls == poisonedChunks == 21`. Full `-short` suite green.

Merging this should turn #66's `qwp-fuzz` check green (that branch will pick the fix up via rebase or merge once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when server rejections interrupt ordered delivery by recycling the connection and replaying from the affected point.
  * Updated rejection classification for schema-mismatch responses to correctly drop-and-continue behavior.
  * Reduced worst-case shutdown time during error handling.
* **Tests**
  * Tightened reconnection, replay, and capped-drop scenarios to better stress shutdown timing and rejection handling.
  * Updated fuzz expectations to match deterministic schema-mismatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
